### PR TITLE
Feature decorator add overline

### DIFF
--- a/src/terminal/CommandBuilder.cpp
+++ b/src/terminal/CommandBuilder.cpp
@@ -292,6 +292,8 @@ namespace impl // {{{ some command generator helpers
 				case 47: emitCommand<SetBackgroundColor>(_output, IndexedColor::White); break;
 				case 48: i = parseColor<SetBackgroundColor>(_ctx, i, _output); break;
 				case 49: emitCommand<SetBackgroundColor>(_output, DefaultColor{}); break;
+                case 53: emitCommand<SetGraphicsRendition>(_output, GraphicsRendition::Overline); break;
+                case 55: emitCommand<SetGraphicsRendition>(_output, GraphicsRendition::NoOverline); break;
                 // 58 is reserved, but used for setting underline/decoration colors by some other VTEs (such as mintty, kitty, libvte)
                 case 58: i = parseColor<SetUnderlineColor>(_ctx, i, _output); break;
 				case 90: emitCommand<SetForegroundColor>(_output, BrightColor::Black); break;

--- a/src/terminal/Commands.cpp
+++ b/src/terminal/Commands.cpp
@@ -98,6 +98,10 @@ string to_string(GraphicsRendition s)
             return "DottedUnderlined";
         case GraphicsRendition::DashedUnderline:
             return "DashedUnderlined";
+        case GraphicsRendition::Overline:
+            return "Overline";
+        case GraphicsRendition::NoOverline:
+            return "NoOverline";
     }
     return "?";
 }

--- a/src/terminal/Commands.h
+++ b/src/terminal/Commands.h
@@ -100,6 +100,8 @@ enum class GraphicsRendition {
     CurlyUnderlined = 30,   //!< Curly line below the baseline.
     DottedUnderline = 31,   //!< Dotted line below the baseline.
     DashedUnderline = 32,   //!< Dashed line below the baseline.
+    Overline = 53,          //!< Overlined glyph
+    NoOverline = 55,        //!< Reverses Overline.
 };
 
 std::string to_string(GraphicsRendition s);

--- a/src/terminal/Screen.cpp
+++ b/src/terminal/Screen.cpp
@@ -893,6 +893,9 @@ void Screen::operator()(SetGraphicsRendition const& v)
         case GraphicsRendition::DashedUnderline:
             buffer_->graphicsRendition.styles |= CharacterStyleMask::DashedUnderline;
             break;
+        case GraphicsRendition::Overline:
+            buffer_->graphicsRendition.styles |= CharacterStyleMask::Overline;
+            break;
         case GraphicsRendition::Normal:
             buffer_->graphicsRendition.styles &= ~(CharacterStyleMask::Bold | CharacterStyleMask::Faint);
             break;
@@ -913,6 +916,9 @@ void Screen::operator()(SetGraphicsRendition const& v)
             break;
         case GraphicsRendition::NoCrossedOut:
             buffer_->graphicsRendition.styles &= ~CharacterStyleMask::CrossedOut;
+            break;
+        case GraphicsRendition::NoOverline:
+            buffer_->graphicsRendition.styles &= ~CharacterStyleMask::Overline;
             break;
     }
 }

--- a/src/terminal/ScreenBuffer.h
+++ b/src/terminal/ScreenBuffer.h
@@ -53,6 +53,7 @@ class CharacterStyleMask {
         DashedUnderline = (1 << 11),
         Framed = (1 << 12),
         Encircled = (1 << 13),
+        Overline = (1 << 14),
 	};
 
 	constexpr CharacterStyleMask() : mask_{} {}
@@ -662,7 +663,7 @@ namespace fmt {
         auto format(terminal::CharacterStyleMask const& _mask, FormatContext& ctx)
         {
             using Mask = terminal::CharacterStyleMask;
-            auto constexpr mappings = std::array<std::pair<Mask, std::string_view>, 10>{
+            auto constexpr mappings = std::array<std::pair<Mask, std::string_view>, 11>{
                 std::pair{Mask::Bold, "bold"},
                 std::pair{Mask::Faint, "faint"},
                 std::pair{Mask::Italic, "italic"},
@@ -672,7 +673,8 @@ namespace fmt {
                 std::pair{Mask::Hidden, "hidden"},
                 std::pair{Mask::CrossedOut, "crossedOut"},
                 std::pair{Mask::DoublyUnderlined, "doublyUnderlined"},
-                std::pair{Mask::CurlyUnderlined, "curlyUnderlined"}
+                std::pair{Mask::CurlyUnderlined, "curlyUnderlined"},
+                std::pair{Mask::Overline, "overline"}
             };
             int i = 0;
             std::ostringstream os;

--- a/src/terminal_view/DecorationRenderer.h
+++ b/src/terminal_view/DecorationRenderer.h
@@ -38,6 +38,8 @@ enum class Decorator {
     DottedUnderline,
     /// Draws a dashed underline
     DashedUnderline,
+    /// Draws an overline
+    Overline,
     /// Draws a strike-through line
     CrossedOut,
     /// Draws a box around the glyph, this is literally the bounding box of a grid cell.


### PR DESCRIPTION
I've added the feature to render overlines in text. For testing I've been using the following shell command.

`echo -e "The \033[53mtest is\033[55m done"`