### PR TITLE
set min Size of window so it does not crash when the width is near zero

### DIFF
--- a/src/contour/TerminalWidget.cpp
+++ b/src/contour/TerminalWidget.cpp
@@ -671,6 +671,7 @@ void TerminalWidget::resizeGL(int _width, int _height)
     auto const viewHeight = height();
 
     terminalView_->resize(viewWidth, viewHeight);
+    setMinimumSize(terminalView_->cellWidth() * 3, terminalView_->cellHeight() * 2);
     terminalView_->setProjection(
         ortho(
             0.0f, static_cast<float>(viewWidth),      // left, right


### PR DESCRIPTION
The problem is when the width is near zero then the cell size width will be zero and when that happens there are multible places that can not handle that case.

So to prevent I just have set the minimum Size of the window. 

I don't know it that is the best way to handle the problem, but from my view it is the fastest way to fix it.

Fixes #157.