### PR TITLE
Adds screen buffer capture VT sequence and VT sequence for requesting window/text area's character size.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -24,6 +24,7 @@
 - Adds terminal identification environment variables `TERMINAL_NAME`, `TERMINAL_VERSION_TRIPLE` and `TERMINAL_VERSION_STRING`.
 - Adds config option `profile.*.fonts.TYPE.weight: WEIGHT` and `profile.*.fonts.TYPE.slant: SLANT` options (optional) along with `profile.*.fonts.TYPE.family: STRING`.
 - Adds VT sequence `CSI 18 t` and `CSI 19 t` for getting screen character size. Responds with `CSI 8 ; <columns> ; <rows> t` and  `CSI 9 ; <columns> ; <rows> t` respectively.
+- Adds VT sequence to capture the current screen buffer `CSI > LineMode ; StartLine ; LineCount t` giving the respone back on stdin via `OSC 314 ; <screen buffer> ST`, and feature detection via `DA1` number `314`.
 
 ### 0.1.1 (2020-12-31)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,7 @@
 - Adds config option `profile.*.fonts.TYPE.weight: WEIGHT` and `profile.*.fonts.TYPE.slant: SLANT` options (optional) along with `profile.*.fonts.TYPE.family: STRING`.
 - Adds terminal identification environment variables `TERMINAL_NAME`, `TERMINAL_VERSION_TRIPLE` and `TERMINAL_VERSION_STRING`.
 - Adds config option `profile.*.fonts.TYPE.weight: WEIGHT` and `profile.*.fonts.TYPE.slant: SLANT` options (optional) along with `profile.*.fonts.TYPE.family: STRING`.
+- Adds VT sequence `CSI 18 t` and `CSI 19 t` for getting screen character size. Responds with `CSI 8 ; <columns> ; <rows> t` and  `CSI 9 ; <columns> ; <rows> t` respectively.
 
 ### 0.1.1 (2020-12-31)
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,8 @@
 # Milestone 0.2.0 checklist
 
-- [ ] CI: use cpack to build linux zip's (and maybe deb files?)
-- [ ] CI: ensure installers contain right version + git sha + prerelease suffix
-- [ ] CI: Fix ubuntu 18.04 dependencies
+- [ ] FIXME: `reset` resets screen size to 80x25, should remain actual one.
+- [ ] debuglog: filter by logging tags (in a somewhat performant way), so the debuglog (when enabled) is not flooding.
+- [ ] CopyLastMarkRange seems not to work (at least for double-line prompts in zsh/p10k)
 
 - [ ] Font: support DirectWrite backend
 - [ ] Font: fix framed underline

--- a/src/contour/CMakeLists.txt
+++ b/src/contour/CMakeLists.txt
@@ -23,6 +23,7 @@ CIncludeMe(contour.yml "${CMAKE_CURRENT_BINARY_DIR}/contour_yaml.h" "default_con
 set(contour_SRCS
     Actions.cpp Actions.h
     BackgroundBlur.cpp BackgroundBlur.h
+    CaptureScreen.cpp CaptureScreen.h
     Config.cpp Config.h
     Controller.cpp Controller.h
     FileChangeWatcher.cpp FileChangeWatcher.h

--- a/src/contour/CaptureScreen.cpp
+++ b/src/contour/CaptureScreen.cpp
@@ -1,0 +1,341 @@
+/**
+ * This file is part of the "libterminal" project
+ *   Copyright (c) 2019-2020 Christian Parpart <christian@parpart.family>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <contour/CaptureScreen.h>
+
+#include <crispy/utils.h>
+
+#include <fmt/format.h>
+
+#include <algorithm>
+#include <cstdlib>
+#include <fstream>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <ostream>
+#include <string>
+#include <string_view>
+#include <tuple>
+
+#if defined(_WIN32)
+    #include <Winsock2.h>
+    #include <Windows.h>
+#else
+    #include <sys/select.h>
+    #include <termios.h>
+    #include <unistd.h>
+    #include <fcntl.h>
+#endif
+
+#if !defined(STDIN_FILENO)
+    #define STDIN_FILENO 0
+#endif
+
+using std::cerr;
+using std::copy_n;
+using std::cout;
+using std::make_unique;
+using std::nullopt;
+using std::ofstream;
+using std::optional;
+using std::ostream;
+using std::reference_wrapper;
+using std::stoi;
+using std::string;
+using std::string_view;
+using std::tuple;
+using std::unique_ptr;
+
+using namespace std::string_view_literals;
+
+namespace contour {
+
+namespace
+{
+    struct TTY
+    {
+        bool configured = false;
+#if !defined(_WIN32)
+        int fd = -1;
+        termios savedModes{};
+#else
+        DWORD savedModes{};
+#endif
+
+        ~TTY()
+        {
+#if !defined(_WIN32)
+            tcsetattr(fd, TCSANOW, &savedModes);
+#else
+            auto stdinHandle = GetStdHandle(STD_INPUT_HANDLE);
+            SetConsoleMode(stdinHandle, savedModes);
+#endif
+        }
+
+        TTY()
+        {
+#if !defined(_WIN32)
+            fd = open("/dev/tty", O_RDWR);
+            if (fd < 0)
+            {
+                cerr << "Could not open current terminal.\n";
+                return;
+            }
+
+            if (tcgetattr(fd, &savedModes) < 0)
+                return;
+
+            // disable buffered input
+            termios tio = savedModes;
+            tio.c_lflag &= ~(ICANON | ECHO);
+
+            // {{{ in case I want to do more with this
+            // // input flags
+            // tio.c_iflag &= ~IXON;     // Disable CTRL-S / CTRL-Q on output.
+            // tio.c_iflag &= ~IXOFF;    // Disable CTRL-S / CTRL-Q on input.
+            // tio.c_iflag &= ~ICRNL;    // Ensure CR isn't translated to NL.
+            // tio.c_iflag &= ~INLCR;    // Ensure NL isn't translated to CR.
+            // tio.c_iflag &= ~IGNCR;    // Ensure CR isn't ignored.
+            // tio.c_iflag &= ~IMAXBEL;  // Ensure beeping on full input buffer isn't enabled.
+            // tio.c_iflag &= ~ISTRIP;   // Ensure stripping of 8th bit on input isn't enabled.
+            //
+            // // output flags
+            // tio.c_oflag &= ~OPOST;   // Don't enable implementation defined output processing.
+            // tio.c_oflag &= ~ONLCR;   // Don't map NL to CR-NL.
+            // tio.c_oflag &= ~OCRNL;   // Don't map CR to NL.
+            // tio.c_oflag &= ~ONLRET;  // Don't output CR.
+            // }}}
+
+            if (tcsetattr(fd, TCSANOW, &tio) < 0)
+                return;
+
+            configured = true;
+#else
+            auto stdinHandle = GetStdHandle(STD_INPUT_HANDLE);
+
+            GetConsoleMode(stdinHandle, &savedModes);
+
+            DWORD modes = savedModes;
+            modes |= ENABLE_VIRTUAL_TERMINAL_INPUT;
+            modes &= ~ENABLE_LINE_INPUT;
+            modes &= ~ENABLE_ECHO_INPUT;
+
+            SetConsoleMode(stdinHandle, modes);
+            configured = true;
+#endif
+        }
+
+        int wait(timeval* _timeout)
+        {
+#if defined(_WIN32)
+            auto const fd0 = GetStdHandle(STD_INPUT_HANDLE);
+            DWORD const timeoutMillis = _timeout->tv_sec * 1000 + _timeout->tv_usec / 1000;
+            DWORD const result = WaitForSingleObject(fd0, timeoutMillis);
+            switch (result)
+            {
+                case WSA_WAIT_EVENT_0:
+                    return 1;
+                case WSA_WAIT_TIMEOUT:
+                    return 0;
+                case WAIT_FAILED:
+                case WAIT_ABANDONED:
+                default:
+                    return -1;
+            }
+#else
+            fd_set sin, sout, serr;
+            FD_ZERO(&sin);
+            FD_ZERO(&sout);
+            FD_ZERO(&serr);
+            FD_SET(fd, &sin);
+            auto const watermark = fd + 1;
+            return select(watermark, &sin, &sout, &serr, _timeout);
+#endif
+        }
+
+        int write(char const* _buf, size_t _size)
+        {
+#if defined(_WIN32)
+            DWORD nwritten{};
+            if (WriteFile(GetStdHandle(STD_OUTPUT_HANDLE), _buf, static_cast<DWORD>(_size), &nwritten, nullptr))
+                return static_cast<int>(nwritten);
+            else
+                return -1;
+#else
+            return ::write(fd, _buf, _size);
+#endif
+        }
+
+        int write(string_view _text)
+        {
+            return write(_text.data(), _text.size());
+        }
+
+        int read(void* _buf, size_t _size)
+        {
+#if defined(_WIN32)
+            DWORD nread{};
+            if (ReadFile(GetStdHandle(STD_INPUT_HANDLE), _buf, static_cast<DWORD>(_size), &nread, nullptr))
+                return static_cast<int>(nread);
+            else
+                return -1;
+#else
+            return ::read(fd, _buf, _size);
+#endif
+        }
+
+        optional<tuple<int, int>> screenSize(timeval* _timeout)
+        {
+            // Naive implementation. TODO: use select() to poll and time out properly.
+            // cout << "\033[18t"; // get line/column count from terminal
+            // cout.flush();
+            write("\033[16t");
+
+            if (wait(_timeout) <= 0)
+                return nullopt;
+
+            // Consume reply: `CSI 8 ; <LINES> ; <COLUMNS> t`
+            string reply;
+            for (;;)
+            {
+                char ch{};
+                if (read(&ch, sizeof(ch)) != sizeof(ch))
+                    return nullopt;
+
+                if (ch == 't')
+                    break;
+
+                reply.push_back(ch);
+            }
+
+            auto const screenSizeReply = crispy::split(reply, ';');
+            auto const columns = stoi(string(screenSizeReply.at(1)));
+            auto const lines = stoi(string(screenSizeReply.at(2)));
+
+            return tuple{columns, lines};
+        }
+    };
+
+    auto constexpr ReplyPrefix = "\033]314;"sv; // DCS 314 ;
+    auto constexpr ReplySuffix = "\033\\"sv;    // ST
+
+    bool readCaptureChunk(TTY& _input, timeval* _timeout, string& _reply)
+    {
+        timeval timeout = *_timeout;
+        // Response is of format: OSC 314 ; <screen capture> ST`
+        long long int n = 0;
+        while (true)
+        {
+            int rv = _input.wait(&timeout);
+            if (rv < 0)
+            {
+                perror("select");
+                return false;
+            }
+            else if (rv == 0)
+            {
+                cerr << "VTE did not respond to CAPTURE `CSI > Ps ; Ps ; Ps t`.\n";
+                return false;
+            }
+
+            char buf[4096];
+            rv = _input.read(buf, sizeof(buf));
+            if (rv < 0)
+            {
+                perror("read");
+                return false;
+            }
+
+            copy_n(buf, rv, back_inserter(_reply));
+
+            if (n == 0 && !crispy::startsWith(string_view(_reply), ReplyPrefix))
+            {
+                cerr << fmt::format("Invalid response from terminal received. Does not start with expected reply prefix.\n");
+                return false;
+            }
+            n++;
+
+            if (crispy::endsWith(string_view(_reply), ReplySuffix))
+                break;
+        }
+
+        return true;
+    }
+}
+
+bool captureScreen(CaptureSettings const& _settings)
+{
+    auto tty = TTY{};
+    if (!tty.configured)
+        return false;
+
+    auto constexpr MicrosPerSecond = 1000000;
+    auto const timeoutMicros = int(_settings.timeout * MicrosPerSecond);
+    auto timeout = timeval{};
+    timeout.tv_sec = timeoutMicros / MicrosPerSecond;
+    timeout.tv_usec = timeoutMicros % MicrosPerSecond;
+
+    auto const screenSizeOpt = tty.screenSize(&timeout);
+    if (!screenSizeOpt.has_value())
+    {
+        cerr << "Could not get current screen size.\n";
+        return false;
+    }
+    auto const [numColumns, numLines] = screenSizeOpt.value();
+
+    if (_settings.verbosityLevel > 0)
+        cout << fmt::format("Screen size: {}x{}. Capturing lines {} to file {}.\n",
+                            numColumns, numLines,
+                            _settings.logicalLines ? "logical" : "physical",
+                            _settings.lineCount,
+                            _settings.outputFile.data());
+
+    tty.write(fmt::format("\033[>{};{}t",
+                          _settings.logicalLines ? '1' : '0',
+                          _settings.lineCount));
+
+    // request screen capture
+    string reply;
+    reply.reserve(numColumns * std::max(_settings.lineCount, numLines));
+
+    reference_wrapper<ostream> output(cout);
+    unique_ptr<ostream> customOutput;
+    if (_settings.outputFile != "-"sv)
+    {
+        cout << "Writing to file.\n";
+        customOutput = make_unique<ofstream>(_settings.outputFile.data());
+        output = *customOutput;
+    }
+    else
+        cerr << "Writing to stdout.\n";
+
+    while (true)
+    {
+        if (!readCaptureChunk(tty, &timeout, reply))
+            return false;
+
+        auto const payload = string_view(reply.data() + ReplyPrefix.size(),
+                                         reply.size() - ReplyPrefix.size() - ReplySuffix.size());
+
+        if (payload.empty())
+            break;
+
+        output.get().write(payload.data(), payload.size());
+        reply.clear();
+    }
+    return true;
+}
+
+} // end namespace

--- a/src/contour/CaptureScreen.h
+++ b/src/contour/CaptureScreen.h
@@ -1,0 +1,31 @@
+/**
+ * This file is part of the "libterminal" project
+ *   Copyright (c) 2019-2020 Christian Parpart <christian@parpart.family>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string_view>
+
+namespace contour {
+
+struct CaptureSettings
+{
+    bool logicalLines = false;          // -l
+    double timeout = 1.0f;              // -t <timeout in seconds>
+    std::string_view outputFile;        // -o <outputfile>
+    int verbosityLevel = 0;             // -v, -q (XXX intentionally not parsed currently!)
+    int lineCount = 0;                  // (use terminal default)
+};
+
+bool captureScreen(CaptureSettings const& _settings);
+
+}

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -290,7 +290,7 @@ void softLoadValue(YAML::Node const& _node, string const& _name, T& _store, U co
 
 void softLoadPermission(YAML::Node const& _node, string const& _name, Permission& _out)
 {
-    if (auto const valueNode = _node[_name]; valueNode.IsScalar())
+    if (auto const valueNode = _node[_name]; valueNode && valueNode.IsScalar())
     {
         auto const value = valueNode.as<string>();
         if (value == "allow")
@@ -934,8 +934,8 @@ TerminalProfile loadTerminalProfile(YAML::Node const& _node,
 
     if (auto const permissions = _node["permissions"]; permissions && permissions.IsMap())
     {
+        softLoadPermission(permissions, "capture_buffer", profile.permissions.captureBuffer);
         softLoadPermission(permissions, "change_font", profile.permissions.changeFont);
-        // ...
     }
 
     if (auto fonts = _node["font"]; fonts)

--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -70,6 +70,7 @@ struct TerminalProfile {
     int tabWidth;
 
     struct {
+        Permission captureBuffer = Permission::Ask;
         Permission changeFont = Permission::Ask;
     } permissions;
 

--- a/src/contour/TerminalWidget.h
+++ b/src/contour/TerminalWidget.h
@@ -138,6 +138,7 @@ class TerminalWidget :
     void bell() override;
     void bufferChanged(terminal::ScreenType) override;
     void screenUpdated() override;
+    void requestCaptureBuffer(int _absoluteStartLine, int _lineCount) override;
     void setFontDef(terminal::FontDef const& _fontDef) override;
     void copyToClipboard(std::string_view const& _data) override;
     void dumpState() override;
@@ -148,7 +149,8 @@ class TerminalWidget :
     void resizeWindow(int /*_width*/, int /*_height*/, bool /*_unitInPixels*/) override;
     void setWindowTitle(std::string_view const& /*_title*/) override;
     void setTerminalProfile(std::string const& _configProfileName) override;
-    bool requestPermissionChangeFont();
+
+    bool requestPermission(config::Permission _allowedByConfig, std::string_view _topicText);
 
   signals:
     void showNotification(QString const& _title, QString const& _body);
@@ -242,6 +244,7 @@ class TerminalWidget :
 
     struct {
         std::optional<bool> changeFont;
+        std::map<std::string, bool> mapping;
     } rememberedPermissions_;
 
     // render state cache

--- a/src/contour/contour.yml
+++ b/src/contour/contour.yml
@@ -83,8 +83,11 @@ profiles:
         #
         # Default for all of these entries should be: "ask".
         permissions:
-            # Allows changing the font via `OSC 50 ; Pt ST` (this is the regular font face).
+            # Allows changing the font via `OSC 50 ; Pt ST`.
             change_font: ask
+            # Allows capturing the screen buffer via `CSI > Pm ; Ps ; Pc ST`.
+            # The response can be read from stdin as sequence `OSC 314 ; <screen capture> ST`
+            capture_buffer: ask
 
         # Font related configuration (font face, styles, size, rendering mode).
         font:

--- a/src/contour/main.cpp
+++ b/src/contour/main.cpp
@@ -14,6 +14,7 @@
 #include <contour/Config.h>
 #include <contour/Controller.h>
 #include <contour/TerminalWidget.h>
+#include <contour/CaptureScreen.h>
 
 #include <terminal/Parser.h>
 
@@ -27,9 +28,14 @@
 
 #include <algorithm>
 #include <cstdio>
+#include <fstream>
+#include <iomanip>
 #include <iomanip>
 #include <iostream>
+#include <iostream>
 #include <numeric>
+#include <string>
+#include <string_view>
 
 #if !defined(_WIN32)
 #include <unistd.h>
@@ -123,8 +129,8 @@ int main(int argc, char* argv[])
                     {
                         CLI::Option{"logical", CLI::Value{false}, "Tells the terminal to use logical lines for counting and capturing."},
                         CLI::Option{"timeout", CLI::Value{1.0}, "Sets timeout seconds to wait for terminal to respond."},
-                        CLI::Option{"count", CLI::Value{0}, "The number of lines to capture"},
-                        CLI::Option{"output", CLI::Value{""s}, "Output file name to store the screen capture to.", "FILE", CLI::Presence::Required},
+                        CLI::Option{"lines", CLI::Value{0u}, "The number of lines to capture"},
+                        CLI::Option{"output", CLI::Value{""s}, "Output file name to store the screen capture to. If - (dash) is given, the capture will be written to standard output.", "FILE", CLI::Presence::Required},
                     }
                 }
             }
@@ -152,6 +158,20 @@ int main(int argc, char* argv[])
         {
             std::cout << CLI::helpText(cliDef, helpStyle(), screenWidth());
             return EXIT_SUCCESS;
+        }
+
+        if (flags.get<bool>("contour.capture"))
+        {
+            auto captureSettings = contour::CaptureSettings{};
+            captureSettings.logicalLines = flags.get<bool>("contour.capture.logical");
+            captureSettings.timeout = flags.get<double>("contour.capture.timeout");
+            captureSettings.lineCount = flags.get<unsigned>("contour.capture.lines");
+            captureSettings.outputFile = flags.get<string>("contour.capture.output");
+
+            if (contour::captureScreen(captureSettings))
+                return EXIT_SUCCESS;
+            else
+                return EXIT_FAILURE;
         }
 
         if (flags.get<bool>("contour.parser-table"))

--- a/src/crispy/utils.h
+++ b/src/crispy/utils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -100,5 +101,36 @@ inline std::unordered_map<std::string_view, std::string_view> splitKeyValuePairs
 
     return params;
 }
+
+template <typename Ch>
+bool startsWith(std::basic_string_view<Ch> _text, std::basic_string_view<Ch> _prefix)
+{
+    if (_text.size() < _prefix.size())
+        return false;
+
+    for (size_t i = 0; i < _prefix.size(); ++i)
+        if (_text[i] != _prefix[i])
+            return false;
+
+    return true;
+}
+
+template <typename Ch>
+bool endsWith(std::basic_string_view<Ch> _text, std::basic_string_view<Ch> _prefix)
+{
+    if (_text.size() < _prefix.size())
+        return false;
+
+    for (size_t i = 0; i < _prefix.size(); ++i)
+        if (_text[_text.size() - _prefix.size() + i] != _prefix[i])
+            return false;
+
+    return true;
+}
+
+struct finally {
+    std::function<void()> hook{};
+    ~finally() { hook(); }
+};
 
 } // end namespace

--- a/src/terminal/Functions.h
+++ b/src/terminal/Functions.h
@@ -295,6 +295,7 @@ constexpr inline auto TBC         = detail::CSI(std::nullopt, 0, 1, std::nullopt
 constexpr inline auto VPA         = detail::CSI(std::nullopt, 0, 1, std::nullopt, 'd', VTType::VT100, "VPA", "Vertical Position Absolute");
 constexpr inline auto WINMANIP    = detail::CSI(std::nullopt, 1, 3, std::nullopt, 't', VTType::VT525, "WINMANIP", "Window Manipulation");
 constexpr inline auto XTSMGRAPHICS= detail::CSI('?', 2, 4, std::nullopt, 'S', VTType::VT525 /*XT*/, "XTSMGRAPHICS", "Setting/getting Sixel/ReGIS graphics settings.");
+constexpr inline auto CAPTURE     = detail::CSI('>', 0, 2, std::nullopt, 't', VTType::VT525 /*Extension*/, "CAPTURE", "Report screen buffer capture.");
 
 // DCS functions
 constexpr inline auto STP         = detail::DCS(std::nullopt, 0, 0, '$', 'p', VTType::VT525, "STP", "Set Terminal Profile");
@@ -370,6 +371,7 @@ inline auto const& functions() noexcept
 
             // CSI
             ANSISYSSC,
+            CAPTURE,
             CBT,
             CHA,
             CHT,

--- a/src/terminal/Grid.h
+++ b/src/terminal/Grid.h
@@ -638,10 +638,7 @@ inline Line& Grid::lineAt(int _line) noexcept
 {
     assert(crispy::ascending(1 - historyLineCount(), _line, screenSize_.height));
 
-    if (_line > 0)
-        return *next(lines_.begin(), historyLineCount() + _line - 1);
-    else
-        return *next(lines_.begin(), -_line);
+    return *next(lines_.begin(), historyLineCount() + _line - 1);
 }
 
 inline Line const& Grid::lineAt(int _line) const noexcept

--- a/src/terminal/Grid.h
+++ b/src/terminal/Grid.h
@@ -437,6 +437,7 @@ class Line { // {{{
     Flags markedFlag() const noexcept { return marked() ? Line::Flags::Marked : Line::Flags::None; }
 
     std::string toUtf8() const;
+    std::string toUtf8Trimmed() const;
 
     void setText(std::string_view _u8string);
 
@@ -553,6 +554,11 @@ class Grid {
     /// Converts a relative line number into an absolute line number.
     int toAbsoluteLine(int _relativeLine) const noexcept;
 
+    /// Converts an absolute line number into a relative line number.
+    int toRelativeLine(int _absoluteLine) const noexcept;
+
+    int computeRelativeLineNumberFromBottom(int _n) const noexcept;
+
     /// Gets a reference to the cell relative to screen origin (top left, 1:1).
     Cell& at(Coordinate const& _coord) noexcept;
 
@@ -649,6 +655,11 @@ inline Line const& Grid::lineAt(int _line) const noexcept
 inline int Grid::toAbsoluteLine(int _relativeLine) const noexcept
 {
     return historyLineCount() + _relativeLine - 1;
+}
+
+inline int Grid::toRelativeLine(int _absoluteLine) const noexcept
+{
+    return _absoluteLine - historyLineCount();
 }
 
 inline Cell& Grid::at(Coordinate const& _coord) noexcept

--- a/src/terminal/Screen.cpp
+++ b/src/terminal/Screen.cpp
@@ -1828,6 +1828,22 @@ void Screen::requestPixelSize(RequestPixelSize _area)
     }
 }
 
+void Screen::requestCharacterSize(RequestPixelSize _area) // TODO: rename RequestPixelSize to RequestArea?
+{
+    switch (_area)
+    {
+        case RequestPixelSize::TextArea:
+            reply("\033[8;{};{}t", size_.height, size_.width);
+            break;
+        case RequestPixelSize::WindowArea:
+            reply("\033[9;{};{}t", size_.height, size_.width);
+            break;
+        case RequestPixelSize::CellArea:
+            assert(!"Screen.requestCharacterSize: Doesn't make sense, and cannot be called, therefore, fortytwo.");
+            break;
+    }
+}
+
 void Screen::requestStatusString(RequestStatusString _value)
 {
     // xterm responds with DCS 1 $ r Pt ST for valid requests

--- a/src/terminal/Screen.cpp
+++ b/src/terminal/Screen.cpp
@@ -51,6 +51,7 @@ using namespace crispy;
 using namespace std::string_view_literals;
 
 using std::accumulate;
+using std::clamp;
 using std::array;
 using std::cerr;
 using std::distance;
@@ -78,6 +79,7 @@ namespace // {{{ helper
 {
     class VTWriter {
       public:
+        // TODO: compare with old sgr value set instead to be more generic in reusing stuff
         using Writer = std::function<void(char const*, size_t)>;
 
         explicit VTWriter(Writer writer) : writer_{std::move(writer)} {}
@@ -157,6 +159,12 @@ namespace // {{{ helper
             }
         }
 
+        void sgr_rewind()
+        {
+            swap(lastSGR_, sgr_);
+            sgr_.clear();
+        }
+
         void sgr_add(GraphicsRendition m)
         {
             sgr_add(static_cast<unsigned>(m));
@@ -164,7 +172,8 @@ namespace // {{{ helper
 
         void setForegroundColor(Color const& _color)
         {
-            if (true) // _color != currentForegroundColor_)
+            //if (true) // _color != currentForegroundColor_)
+            if (_color != currentForegroundColor_)
             {
                 currentForegroundColor_ = _color;
                 if (holds_alternative<IndexedColor>(_color))
@@ -230,6 +239,7 @@ namespace // {{{ helper
 
       private:
         Writer writer_;
+        std::vector<unsigned> lastSGR_;
         std::vector<unsigned> sgr_;
         std::stringstream sstr;
         Color currentForegroundColor_ = DefaultColor{};
@@ -506,8 +516,9 @@ std::string Screen::screenshot(function<string(int)> const& _postLine) const
     auto result = std::stringstream{};
     auto writer = VTWriter(result);
 
-    for (int const row : crispy::times(1, size_.height))
+    for (int const absoluteRow : crispy::times(1, grid().historyLineCount() + size_.height))
     {
+        auto const row = absoluteRow - grid().historyLineCount();
         for (int const col : crispy::times(1, size_.width))
         {
             Cell const& cell = at({row, col});
@@ -831,6 +842,7 @@ void Screen::sendDeviceAttributes()
     auto const attrs = to_params(
         DeviceAttributes::AnsiColor |
         DeviceAttributes::AnsiTextLocator |
+        DeviceAttributes::CaptureScreenBuffer |
         DeviceAttributes::Columns132 |
         //TODO: DeviceAttributes::NationalReplacementCharacterSets |
         //TODO: DeviceAttributes::RectangularEditing |
@@ -1217,6 +1229,66 @@ void Screen::notify(string const& _title, string const& _content)
 {
     std::cout << "Screen.NOTIFY: title: '" << _title << "', content: '" << _content << "'\n";
     eventListener_.notify(_title, _content);
+}
+
+void Screen::captureBuffer(int _lineCount, bool _logicalLines)
+{
+    // TODO: Unit test case! (for ensuring line numbering and limits are working as expected)
+
+    auto capturedBuffer = std::string();
+    auto writer = VTWriter([&](auto buf, auto len) { capturedBuffer += string_view(buf, len); });
+
+    // TODO: when capturing _lineCount < screenSize.height, start at the lowest non-empty line.
+    auto const relativeStartLine = _logicalLines ? grid().computeRelativeLineNumberFromBottom(_lineCount)
+                                                 : size_.height - _lineCount + 1;
+    auto const startLine = clamp(1 - historyLineCount(), relativeStartLine, size_.height);
+
+    // dumpState();
+
+    auto const lineCount = size_.height - startLine + 1;
+
+    auto const trimSpaceRight = [](string& value)
+    {
+        while (!value.empty() && value.back() == ' ')
+            value.pop_back();
+    };
+
+    for (int const row : crispy::times(startLine, lineCount))
+    {
+        auto const& lineBuffer = grid().lineAt(row);
+
+        if (_logicalLines && lineBuffer.wrapped() && !capturedBuffer.empty())
+            capturedBuffer.pop_back();
+
+        if (!lineBuffer.blank())
+        {
+            for (int const col : crispy::times(1, size_.width))
+            {
+                Cell const& cell = at({row, col});
+                if (!cell.codepointCount())
+                    writer.write(U' ');
+                else
+                    for (char32_t const ch : cell.codepoints())
+                        writer.write(ch);
+            }
+            trimSpaceRight(capturedBuffer);
+        }
+
+        writer.write('\n');
+    }
+
+    while (crispy::endsWith(string_view(capturedBuffer), "\n\n"sv)) // TODO: unit test
+        capturedBuffer.pop_back();
+
+    auto constexpr PageSize = size_t{4096};
+    for (size_t i = 0; i < capturedBuffer.size(); i += PageSize)
+    {
+        auto const start = capturedBuffer.data() + i;
+        auto const count = min(PageSize, capturedBuffer.size() - i);
+        reply("\033]314;{}\033\\", string_view(start, count));
+    }
+
+    reply("\033]314;\033\\"); // mark the end
 }
 
 void Screen::cursorForwardTab(int _count)
@@ -1945,8 +2017,8 @@ void Screen::dumpState(std::string const& _message) const
 
     hline();
     cerr << screenshot([this](int _lineNo) -> string {
-        auto const absoluteLine = grid().toAbsoluteLine(_lineNo);
-        return fmt::format("| {}: {}", absoluteLine, grid().lineAt(_lineNo).flags());
+        //auto const absoluteLine = grid().toAbsoluteLine(_lineNo);
+        return fmt::format("| {:>4}: {}", _lineNo, grid().lineAt(_lineNo).flags());
     });
     hline();
 

--- a/src/terminal/Screen.h
+++ b/src/terminal/Screen.h
@@ -275,6 +275,8 @@ class Screen {
     void hyperlink(std::string const& _id, std::string const& _uri);      // OSC 8
     void notify(std::string const& _title, std::string const& _content);  // OSC 777
 
+    void captureBuffer(int _numLines, bool _logicalLines);
+
     void setForegroundColor(Color const& _color);
     void setBackgroundColor(Color const& _color);
     void setUnderlineColor(Color const& _color);
@@ -543,6 +545,9 @@ class Screen {
 
     int toAbsoluteLine(int _relativeLine) const noexcept { return activeGrid_->toAbsoluteLine(_relativeLine); }
     Coordinate toAbsolute(Coordinate _coord) const noexcept { return {activeGrid_->toAbsoluteLine(_coord.row), _coord.column}; }
+
+    int toRelativeLine(int _absoluteLine) const noexcept { return activeGrid_->toRelativeLine(_absoluteLine); }
+    Coordinate toRelative(Coordinate _coord) const noexcept { return {activeGrid_->toRelativeLine(_coord.row), _coord.column}; }
 
   private:
     void setBuffer(ScreenType _type);

--- a/src/terminal/Screen.h
+++ b/src/terminal/Screen.h
@@ -289,6 +289,7 @@ class Screen {
     void designateCharset(CharsetTable _table, CharsetId _charset);
     void singleShiftSelect(CharsetTable _table);
     void requestPixelSize(RequestPixelSize _area);
+    void requestCharacterSize(RequestPixelSize _area);
     void sixelImage(Size _pixelSize, Image::Data&& _rgba);
     void requestStatusString(RequestStatusString _value);
     void requestTabStops();

--- a/src/terminal/ScreenEvents.h
+++ b/src/terminal/ScreenEvents.h
@@ -43,6 +43,7 @@ class ScreenEvents {
   public:
     virtual ~ScreenEvents() = default;
 
+    virtual void requestCaptureBuffer(int /*_absoluteStartLine*/, int /*_lineCount*/) {}
     virtual std::optional<RGBColor> requestDynamicColor(DynamicColorName /*_name*/) { return std::nullopt; }
     virtual void bell() {}
     virtual void bufferChanged(ScreenType) {}

--- a/src/terminal/Sequencer.cpp
+++ b/src/terminal/Sequencer.cpp
@@ -785,6 +785,12 @@ namespace impl // {{{ some command generator helpers
                 case 16:
                     _screen.requestPixelSize(RequestPixelSize::CellArea);
                     break;
+                case 18:
+                    _screen.requestCharacterSize(RequestPixelSize::TextArea);
+                    break;
+                case 19:
+                    _screen.requestCharacterSize(RequestPixelSize::WindowArea);
+                    break;
                 default:
                     return ApplyResult::Unsupported;
             }

--- a/src/terminal/Sequencer.cpp
+++ b/src/terminal/Sequencer.cpp
@@ -704,6 +704,27 @@ namespace impl // {{{ some command generator helpers
         return ApplyResult::Ok;
     }
 
+    ApplyResult CAPTURE(Sequence const& _seq, Screen& _screen)
+    {
+        // CSI Mode ; [; Count] t
+        //
+        // Mode: 0 = physical lines
+        //       1 = logical lines (unwrapped)
+        //
+        // Count: number of lines to capture from main page aera's bottom upwards
+        //        If omitted or 0, the main page area's line count will be used.
+
+        auto const logicalLines = _seq.param_or(0, 0);
+        if (logicalLines != 0 && logicalLines != 1)
+            return ApplyResult::Invalid;
+
+        auto const lineCount = _seq.param_or(1, _screen.size().height);
+
+        _screen.eventListener().requestCaptureBuffer(lineCount, logicalLines);
+
+        return ApplyResult::Ok;
+    }
+
     ApplyResult HYPERLINK(Sequence const& _seq, Screen& _screen)
     {
         auto const& value = _seq.intermediateCharacters();
@@ -1433,6 +1454,7 @@ ApplyResult Sequencer::apply(FunctionDefinition const& _function, Sequence const
         case SETXPROP: return ApplyResult::Unsupported;
         case SETCWD: return impl::SETCWD(_seq, screen_);
         case HYPERLINK: return impl::HYPERLINK(_seq, screen_);
+        case CAPTURE: return impl::CAPTURE(_seq, screen_);
         case COLORFG: return impl::setOrRequestDynamicColor(_seq, screen_, DynamicColorName::DefaultForegroundColor);
         case COLORBG: return impl::setOrRequestDynamicColor(_seq, screen_, DynamicColorName::DefaultBackgroundColor);
         case COLORCURSOR: return impl::setOrRequestDynamicColor(_seq, screen_, DynamicColorName::TextCursorColor);

--- a/src/terminal/Terminal.cpp
+++ b/src/terminal/Terminal.cpp
@@ -405,6 +405,11 @@ void Terminal::setWordDelimiters(string const& _wordDelimiters)
 }
 
 // {{{ ScreenEvents overrides
+void Terminal::requestCaptureBuffer(int _absoluteStartLine, int _lineCount)
+{
+    return eventListener_.requestCaptureBuffer(_absoluteStartLine, _lineCount);
+}
+
 optional<RGBColor> Terminal::requestDynamicColor(DynamicColorName _name)
 {
     return eventListener_.requestDynamicColor(_name);

--- a/src/terminal/Terminal.h
+++ b/src/terminal/Terminal.h
@@ -45,6 +45,7 @@ class Terminal : public ScreenEvents {
       public:
         virtual ~Events() = default;
 
+        virtual void requestCaptureBuffer(int _absoluteStartLine, int _lineCount) = 0;
         virtual std::optional<RGBColor> requestDynamicColor(DynamicColorName /*_name*/) { return std::nullopt; }
         virtual void bell() {}
         virtual void bufferChanged(ScreenType) {}
@@ -234,6 +235,7 @@ class Terminal : public ScreenEvents {
     }
 
   private:
+    void requestCaptureBuffer(int _absoluteStartLine, int _lineCount) override;
     std::optional<RGBColor> requestDynamicColor(DynamicColorName _name) override;
     void bell() override;
     void bufferChanged(ScreenType) override;

--- a/src/terminal/VTType.cpp
+++ b/src/terminal/VTType.cpp
@@ -61,9 +61,10 @@ string to_params(DeviceAttributes v)
         s += v;
     };
 
-    auto constexpr mappings = array<pair<DeviceAttributes, string_view>, 11>{
+    auto constexpr mappings = array<pair<DeviceAttributes, string_view>, 12>{
         pair{DeviceAttributes::AnsiColor, "22"},
         pair{DeviceAttributes::AnsiTextLocator, "29"},
+        pair{DeviceAttributes::CaptureScreenBuffer, "314"},
         pair{DeviceAttributes::Columns132, "1"},
         pair{DeviceAttributes::NationalReplacementCharacterSets, "9"},
         pair{DeviceAttributes::Printer, "2"},

--- a/src/terminal/VTType.h
+++ b/src/terminal/VTType.h
@@ -54,6 +54,7 @@ enum class DeviceAttributes : uint16_t {
     SixelGraphics = (1 << 8),
     RectangularEditing = (1 << 9),
     Windowing = (1 << 10),
+    CaptureScreenBuffer  = (1 << 11),
 };
 
 constexpr DeviceAttributes operator|(DeviceAttributes a, DeviceAttributes b)

--- a/src/terminal/pty/UnixPty.cpp
+++ b/src/terminal/pty/UnixPty.cpp
@@ -60,6 +60,9 @@ namespace
 #if defined(IUTF8)
         tio.c_iflag |= IUTF8;     // Input is UTF-8; this allows character-erase to be properly applied in cooked mode.
 #endif
+#if defined(IUCLC)
+        tio.c_iflag &= IUCLC;     // Map uppercase characters to lowercase on input (not in POSIX).
+#endif
         tio.c_iflag &= ~IXON;     // Disable CTRL-S / CTRL-Q on output.
         tio.c_iflag &= ~IXOFF;    // Disable CTRL-S / CTRL-Q on input.
         tio.c_iflag &= ~ICRNL;    // Ensure CR isn't translated to NL.

--- a/src/terminal_view/TerminalView.cpp
+++ b/src/terminal_view/TerminalView.cpp
@@ -92,6 +92,11 @@ TerminalView::TerminalView(steady_clock::time_point _now,
     terminal_.screen().setCellPixelSize(renderer_.cellSize());
 }
 
+void TerminalView::requestCaptureBuffer(int _absoluteStartLine, int _lineCount)
+{
+    events_.requestCaptureBuffer(_absoluteStartLine, _lineCount);
+}
+
 optional<RGBColor> TerminalView::requestDynamicColor(DynamicColorName _name)
 {
     switch (_name)

--- a/src/terminal_view/TerminalView.h
+++ b/src/terminal_view/TerminalView.h
@@ -44,6 +44,7 @@ class TerminalView : private Terminal::Events {
         virtual void bell() {}
         virtual void bufferChanged(ScreenType) {}
         virtual void screenUpdated() {}
+        virtual void requestCaptureBuffer(int /*_absoluteStartLine*/, int /*_lineCount*/) {}
         virtual void setFontDef(FontDef const& /*_fontDef*/) {}
         virtual void copyToClipboard(std::string_view const& /*_data*/) {}
         virtual void dumpState() {}
@@ -139,6 +140,7 @@ class TerminalView : private Terminal::Events {
     constexpr WindowMargin const& windowMargin() const noexcept { return windowMargin_; }
 
   private:
+    void requestCaptureBuffer(int _absoluteStartLine, int _lineCount) override;
     std::optional<RGBColor> requestDynamicColor(DynamicColorName _name) override;
     void bell() override;
     void bufferChanged(ScreenType) override;


### PR DESCRIPTION
Implements #168.

## Checklist

- [x] `contour capture output -` writes screen capture back to stdout (for use with pipes). Maybe allow this only if stout is a pipe.
- [x] Ensure very large screen buffers can be captured, too.
- [x] Add mode to retrieve logical lines (unwrapped lines) instead - update spec respectively.
- [x] the CLI option `-h` and `--help` should also print information about this feature.
- [x] backend logic implementation
- [x] feature detection via `DA1` (identification number `314`)
- [x] frontend hooking into the screen capture event
- [x] permission system
- [x] unit tests for backend logic
- [x] changelog entry
- [x] command line program to capture the current terminal's screen buffer.
- [x] Split `CSI 14 t` VT sequence addition into its own commit.
- [x] Verify permission check integration is working!

## CLI Usage

```txt
    contour capture
        Captures the screen buffer of the currently running terminal.

        Options:

            [logical]        Tells the terminal to use logical lines for counting and capturing.
            [timeout FLOAT]  Sets timeout seconds to wait for terminal to respond. [default: 1]
            [lines UINT]     The number of lines to capture [default: 0]
            output STRING    Output file name to store the screen capture to.
```

## Specification

This feature is purely VT sequence based, so it also works across remote connections.

### Sending the screen capture request:

```sh
CSI > Pm ;  Pc t
```
* **Pm:** how to count the lines, 0 raw mapping, 1 for logical line mapping (unwrapping wrapped lines into a single logical one).
* **Pc:** the number of lines to capture from the bottom of the main page area, counting upwards, up until the history top is reached. If omitted, main page area will be captured.

### Response

The response will be received over `stdin` from the terminal in the given format:

```sh
OSC 314 ; <payload> ST
```

With `<payload>` being the textual data that was saved during screen capture.
The response is chunked into multiples of the above sequence until the `<payload>` does not carry any data.