### PR TITLE
Decouple stdin writing thread from stdout reading thread.

### DIFF
--- a/src/contour/TerminalWidget.cpp
+++ b/src/contour/TerminalWidget.cpp
@@ -1641,6 +1641,13 @@ void TerminalWidget::notify(std::string_view const& _title, std::string_view con
                           QString::fromUtf8(_content.data(), static_cast<int>(_content.size())));
 }
 
+void TerminalWidget::reply(std::string_view const& _reply)
+{
+    post([this, data = string(_reply)]() {
+        terminalView_->terminal().sendRaw(data);
+    });
+}
+
 void TerminalWidget::setWindowTitle(std::string_view const& _title)
 {
     post([this, terminalTitle = string(_title)]() {

--- a/src/contour/TerminalWidget.h
+++ b/src/contour/TerminalWidget.h
@@ -142,6 +142,7 @@ class TerminalWidget :
     void copyToClipboard(std::string_view const& _data) override;
     void dumpState() override;
     void notify(std::string_view const& /*_title*/, std::string_view const& /*_body*/) override;
+    void reply(std::string_view const& /*_reply*/) override;
     void onClosed() override;
     void onSelectionComplete() override;
     void resizeWindow(int /*_width*/, int /*_height*/, bool /*_unitInPixels*/) override;

--- a/src/terminal/InputGenerator.cpp
+++ b/src/terminal/InputGenerator.cpp
@@ -456,6 +456,12 @@ bool InputGenerator::generate(FocusOutEvent const&)
     return true;
 }
 
+bool InputGenerator::generate(std::string_view const& _raw)
+{
+    append(_raw);
+    return true;
+}
+
 // {{{ mouse handling
 void InputGenerator::setMouseProtocol(MouseProtocol _mouseProtocol, bool _enabled)
 {

--- a/src/terminal/InputGenerator.h
+++ b/src/terminal/InputGenerator.h
@@ -382,6 +382,9 @@ class InputGenerator {
     bool generate(FocusInEvent const&);
     bool generate(FocusOutEvent const&);
 
+    /// Generates raw input, usually used for sending reply VT sequences.
+    bool generate(std::string_view const& _raw);
+
     /// Swaps out the generated input control sequences.
     void swap(Sequence& _other);
 

--- a/src/terminal/Terminal.cpp
+++ b/src/terminal/Terminal.cpp
@@ -325,11 +325,18 @@ void Terminal::sendPaste(string_view const& _text)
     flushInput();
 }
 
+void Terminal::sendRaw(std::string_view const& _text)
+{
+    inputGenerator_.generate(_text);
+    flushInput();
+}
+
 void Terminal::flushInput()
 {
     inputGenerator_.swap(pendingInput_);
     if (!pendingInput_.empty())
     {
+        // XXX should be the only location that does write to the PTY's stdin to avoid race conditions.
         pty_->write(pendingInput_.data(), pendingInput_.size());
         debuglog().write(crispy::escape(begin(pendingInput_), end(pendingInput_)));
         pendingInput_.clear();
@@ -451,9 +458,9 @@ void Terminal::notify(std::string_view const& _title, std::string_view const& _b
     eventListener_.notify(_title, _body);
 }
 
-void Terminal::reply(string_view const& reply)
+void Terminal::reply(string_view const& _reply)
 {
-    pty_->write(reply.data(), reply.size());
+    eventListener_.reply(_reply);
 }
 
 void Terminal::resetDynamicColor(DynamicColorName _name)

--- a/src/terminal/Terminal.h
+++ b/src/terminal/Terminal.h
@@ -54,6 +54,7 @@ class Terminal : public ScreenEvents {
         virtual void copyToClipboard(std::string_view const& /*_data*/) {}
         virtual void dumpState() {}
         virtual void notify(std::string_view const& /*_title*/, std::string_view const& /*_body*/) {}
+        virtual void reply(std::string_view const& /*_response*/) {}
         virtual void onClosed() {}
         virtual void onSelectionComplete() {}
         virtual void resetDynamicColor(DynamicColorName /*_name*/) {}
@@ -99,6 +100,8 @@ class Terminal : public ScreenEvents {
 
     /// Sends verbatim text in bracketed mode to application.
     void sendPaste(std::string_view const& _text);
+
+    void sendRaw(std::string_view const& _text);
     // }}}
 
     // {{{ screen proxy
@@ -219,7 +222,6 @@ class Terminal : public ScreenEvents {
   private:
     void flushInput();
     void screenUpdateThread();
-    void onScreenReply(std::string_view const& reply);
     void updateCursorVisibilityState(std::chrono::steady_clock::time_point _now) const;
 
     template <typename Renderer, typename... RemainingPasses>

--- a/src/terminal_view/TerminalView.cpp
+++ b/src/terminal_view/TerminalView.cpp
@@ -299,6 +299,11 @@ void TerminalView::notify(std::string_view const& _title, std::string_view const
     events_.notify(_title, _body);
 }
 
+void TerminalView::reply(std::string_view const& _response)
+{
+    events_.reply(_response);
+}
+
 void TerminalView::onClosed()
 {
     events_.onClosed();

--- a/src/terminal_view/TerminalView.h
+++ b/src/terminal_view/TerminalView.h
@@ -48,6 +48,7 @@ class TerminalView : private Terminal::Events {
         virtual void copyToClipboard(std::string_view const& /*_data*/) {}
         virtual void dumpState() {}
         virtual void notify(std::string_view const& /*_title*/, std::string_view const& /*_body*/) {}
+        virtual void reply(std::string_view const& /*_response*/) {}
         virtual void onClosed() {}
         virtual void onSelectionComplete() {}
         virtual void resizeWindow(int /*_width*/, int /*_height*/, bool /*_unitInPixels*/) {}
@@ -147,6 +148,7 @@ class TerminalView : private Terminal::Events {
     void copyToClipboard(std::string_view const& _data) override;
     void dumpState() override;
     void notify(std::string_view const& /*_title*/, std::string_view const& /*_body*/) override;
+    void reply(std::string_view const& /*_response*/) override;
     void onClosed() override;
     void onSelectionComplete() override;
     void resetDynamicColor(DynamicColorName /*_name*/) override;


### PR DESCRIPTION
Decouples stdin writing from stdout reading in Terminal's stdout handler (that sometimes also writes to stdin that should be handled exclusively in the main thread).