### PR TITLE
new (own) (more flexible) CLI parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,31 @@ before version 1.0 is released (headless terminal server with GUI & TUI frontend
 ## CLI - Command Line Interface
 
 ```txt
-Usage: contour [options]
-Contour Terminal Emulator
+  Usage:
 
-Options:
-  -h, --help            Displays this help.
-  -v, --version         Displays version information.
-  -c, --config <PATH>   Path to configuration file to load at startup
-                        [~/.config/contour/contour.yml].
-  -p, --profile <NAME>  Terminal Profile to load.
+    contour [terminal] [config STRING] [profile STRING] [debug STRING] [live-config]
+                       [working-directory STRING] [PROGRAM ARGS...]
+    contour help
+    contour version
+    contour parser-table
+    contour list-debug-tags
+    contour capture [logical] [timeout FLOAT] [count INT] output STRING
+
+  Detailed description:
+
+    contour [terminal]
+        Spawns a new terminal application.
+
+        Options:
+
+            [config STRING]             Path to configuration file to load at startup.
+                                        [default: /home/trapni/.config/contour/contour.yml]
+            [profile STRING]            Terminal Profile to load.
+            [debug STRING]              Enables debug logging, using a comma seperated list of tags.
+            [live-config]               Enables live config reloading. [default: false]
+            [working-directory STRING]  Sets initial working directory. [default: .]
+            [PROGRAM ARGS...]           Executes given program instead of the configuration profided one.
+
 ```
 
 ## Example Configuration File

--- a/src/contour/Config.cpp
+++ b/src/contour/Config.cpp
@@ -598,9 +598,14 @@ void parseInputMapping(Config& _config, YAML::Node const& _mapping)
     }
 }
 
+std::string defaultConfigFilePath()
+{
+    return (configHome() / "contour.yml").string();
+}
+
 Config loadConfig()
 {
-    return loadConfigFromFile((configHome() / "contour.yml").string());
+    return loadConfigFromFile(defaultConfigFilePath());
 }
 
 Config loadConfigFromFile(FileSystem::path const& _fileName)

--- a/src/contour/Config.h
+++ b/src/contour/Config.h
@@ -136,6 +136,7 @@ Config loadConfigFromFile(FileSystem::path const& _fileName);
 Config loadConfig();
 
 std::error_code createDefaultConfig(FileSystem::path const& _path);
+std::string defaultConfigFilePath();
 
 } // namespace contour::config
 

--- a/src/contour/TerminalWidget.cpp
+++ b/src/contour/TerminalWidget.cpp
@@ -1445,7 +1445,7 @@ void TerminalWidget::followHyperlink(terminal::HyperlinkInfo const& _hyperlink)
     if (isLocal && fileInfo.isFile() && fileInfo.isExecutable())
     {
         QStringList args;
-        args.append("-c");
+        args.append("config");
         args.append(QString::fromStdString(config_.backingFilePath.string()));
         args.append(QString::fromUtf8(_hyperlink.path().data(), static_cast<int>(_hyperlink.path().size())));
         QProcess::execute(QString::fromStdString(programPath_), args);
@@ -1453,7 +1453,7 @@ void TerminalWidget::followHyperlink(terminal::HyperlinkInfo const& _hyperlink)
     else if (isLocal && fileInfo.isFile() && editorEnv && *editorEnv)
     {
         QStringList args;
-        args.append("-c");
+        args.append("config");
         args.append(QString::fromStdString(config_.backingFilePath.string()));
         args.append(QString::fromStdString(editorEnv));
         args.append(QString::fromUtf8(_hyperlink.path().data(), static_cast<int>(_hyperlink.path().size())));

--- a/src/crispy/CLI.cpp
+++ b/src/crispy/CLI.cpp
@@ -1,0 +1,894 @@
+/**
+ * This file is part of the "libterminal" project
+ *   Copyright (c) 2019-2020 Christian Parpart <christian@parpart.family>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "CLI.h"
+
+#include <crispy/times.h>
+
+#include <algorithm>
+#include <cassert>
+#include <deque>
+#include <sstream>
+
+#if 0 // !defined(NDEBUG)
+    #include <iostream>
+    #define CLI_DEBUG(that) do { std::cerr << (that) << std::endl; } while (0)
+#else
+    #define CLI_DEBUG(that) do { } while (0)
+#endif
+
+/*
+    Grammar
+    =======
+
+        CLI     := Command
+        Command := NAME Option* SubCommand?
+        Option  := NAME [Value]
+        SubCommand := Command
+
+        Value   := STR | BOOL | FLOAT | INT | UINT
+        NAME    := <name without = or leading -'s>
+
+    Examples
+    ========
+
+        # POSIX style
+        contour --debug '*' capture --logical --timeout=1.0 --output="file.vt"
+        contour --debug '*' capture -l -t 1.0 -o "file.vt"
+
+        capture --config="contour.yml" --debug="foo,bar,com.*"
+
+        # NATURAL STYLE
+        contour debug '*' capture logical timeout 1.0 output "file.vt"
+        capture config "contour.yml" debug "foo,bar,com.*"
+
+        # MIXED STYLE
+        contour -d '*' capture logical timeout 1.0 output "file.vt"
+*/
+
+using std::deque;
+using std::function;
+using std::get;
+using std::holds_alternative;
+using std::invalid_argument;
+using std::map;
+using std::max;
+using std::move;
+using std::nullopt;
+using std::optional;
+using std::ostream;
+using std::pair;
+using std::stod;
+using std::stoi;
+using std::stoul;
+using std::string;
+using std::string_view;
+using std::stringstream;
+using std::vector;
+
+using namespace std::string_view_literals;
+using namespace std::string_literals;
+
+namespace crispy::cli // {{{ Parser
+{
+
+namespace // {{{ helper
+{
+    struct ParseContext {
+        StringViewList const& args;
+        size_t pos = 0;
+
+        deque<Command const*> currentCommand = {};
+        Option const* currentOption = nullptr;
+
+        FlagStore output = {};
+    };
+
+    auto namePrefix(ParseContext const& _context, char _delim = '.') -> string // {{{
+    {
+        string output;
+        for (size_t i = 0; i < _context.currentCommand.size(); ++i) // TODO: use crispy::indexed()
+        {
+            Command const* v = _context.currentCommand.at(i);
+            if (i)
+                output += _delim;
+            output += v->name;
+        }
+
+        return output;
+    } //  }}}
+
+    auto currentToken(ParseContext const& _context) -> string_view
+    {
+        if (_context.pos >= _context.args.size())
+            return string_view{}; // not enough arguments available
+
+        return _context.args.at(_context.pos);
+    }
+
+    auto isTrue(string_view _token) -> bool
+    {
+        return _token == "true" || _token == "yes";
+    }
+
+    auto isFalse(string_view _token) -> bool
+    {
+        return _token == "false" || _token == "no";
+    }
+
+    bool matchPrefix(string_view _text, string_view _prefix)
+    {
+        if (_text.size() < _prefix.size())
+            return false;
+        for (size_t i = 0; i < _prefix.size(); ++i)
+            if (_text[i] != _prefix[i])
+                return false;
+        return true;
+    }
+
+    Option const* findOption(ParseContext const& _context, string_view _name)
+    {
+        for (auto const& option : _context.currentCommand.back()->options)
+            if (option.name == _name)
+                return &option;
+        return nullptr;
+    }
+
+    string_view consumeToken(ParseContext& _context)
+    {
+        // NAME := <just a name>
+        if (_context.pos >= _context.args.size())
+            throw ParserError("Not enough arguments specified.");
+
+        CLI_DEBUG(fmt::format("Consuming token '{}'", currentToken(_context)));
+        return _context.args.at(_context.pos++);
+    }
+
+    /// Parses the given parameter value @p _text with respect to the given @p _option.
+    Value parseValue(ParseContext& _context, string_view _text) // {{{
+    {
+        // Value := STR | BOOL | FLOAT | INT | UINT
+
+        // BOOL
+        if (holds_alternative<bool>(_context.currentOption->value))
+        {
+            if (isTrue(_text))
+                return Value{true};
+
+            if (isFalse(_text))
+                return Value{false};
+
+            throw ParserError("Boolean value expected but something else specified.");
+        }
+
+        // FLOAT
+        try {
+            auto result = Value{stod(string(_text))}; // TODO: avoid malloc
+            if (holds_alternative<double>(_context.currentOption->value))
+                return result;
+            throw ParserError("Floating point value expected but something else specified.");
+        }
+        catch (...) {}
+
+        // UINT
+        try {
+            auto const result = stoul(string(_text));
+            if (holds_alternative<unsigned>(_context.currentOption->value))
+                return Value{unsigned(result)};
+            if (holds_alternative<int>(_context.currentOption->value))
+                return Value{int(result)};
+            throw ParserError("Unsigned integer value expected but something else specified.");
+        }
+        catch (...) {}
+
+        // INT
+        try {
+            auto const result = stoi(string(_text));
+            if (holds_alternative<int>(_context.currentOption->value))
+                return Value{int(result)};
+            throw ParserError("Integer value expected but something else specified.");
+        }
+        catch (...) {}
+
+        // STR
+        return Value{string(_text)};
+    } // }}}
+    Value parseValue(ParseContext& _context) // {{{
+    {
+        if (holds_alternative<bool>(_context.currentOption->value))
+        {
+            auto const text = currentToken(_context);
+            if (isTrue(text))
+            {
+                consumeToken(_context);
+                return Value{true};
+            }
+
+            if (isFalse(text))
+            {
+                consumeToken(_context);
+                return Value{false};
+            }
+
+            // Booleans can be specified just by `--flag` or `flag` without any value
+            // and are considered to be true (implicit).
+            return Value{true};
+        }
+        return parseValue(_context, consumeToken(_context));
+    } // }}}
+
+    struct ScopedOption {
+        ParseContext& context;
+        ScopedOption(ParseContext& _context, Option const& _option) : context{_context} { context.currentOption = &_option; }
+        ~ScopedOption() { context.currentOption = nullptr; }
+    };
+
+    struct ScopedCommand {
+        ParseContext& context;
+        ScopedCommand(ParseContext& _context, Command const& _command) : context{_context} { context.currentCommand.emplace_back(&_command); }
+        ~ScopedCommand() { context.currentCommand.pop_back(); }
+    };
+
+    /// Tries parsing an option name and, if matching, also its value if provided.
+    ///
+    /// @throw ParserError on parserfailures
+    /// @returns nullptr if current token is no option name a pair of an @c Option pointer and its optional value otherwise.
+    optional<pair<Option const*, Value>> tryParseOption(ParseContext& _context)
+    {
+        // NAME [VALUE]
+        // -NAME [VALUE]
+        // --NAME[=VALUE]
+        auto const current = currentToken(_context);
+        if (matchPrefix(current, "--")) // POSIX-style long-option
+        {
+            if (auto const i = current.find('='); i != current.npos)
+            {
+                auto const name = current.substr(2, i - 2);
+                auto const valueText = current.substr(i + 1);
+                if (Option const* opt = findOption(_context, name)) // --NAME=VALUE
+                {
+                    consumeToken(_context);
+                    if (valueText.empty() && !holds_alternative<string>(opt->value))
+                        throw ParserError("Explicit empty value passed but a non-string value expected.");
+
+                    auto const _optionScope = ScopedOption{_context, *opt};
+                    return pair{opt, parseValue(_context, valueText)};
+                }
+            }
+            else
+            {
+                auto const name = current.substr(2);
+                if (Option const* opt = findOption(_context, name)) // --NAME
+                {
+                    consumeToken(_context);
+                    auto const _optionScope = ScopedOption{_context, *opt};
+                    return pair{opt, parseValue(_context)};
+                }
+            }
+        }
+        else if (matchPrefix(current, "-")) // POSIX-style short opt (or otherwise ...)
+        {
+            auto const name = current.substr(1);
+            if (Option const* opt = findOption(_context, name)) // -NAME
+            {
+                consumeToken(_context);
+                auto const _optionScope = ScopedOption{_context, *opt};
+                return pair{opt, parseValue(_context)};
+            }
+        }
+        else // Natural style option
+        {
+            auto const name = current;
+            if (Option const* opt = findOption(_context, name)) // -NAME
+            {
+                consumeToken(_context);
+                auto const _optionScope = ScopedOption{_context, *opt};
+                return pair{opt, parseValue(_context)};
+            }
+        }
+
+        return nullopt;
+    }
+
+    void setOption(ParseContext& _context, string const& _key, Value _value)
+    {
+        CLI_DEBUG(fmt::format("setOption({}): {}", _key, _value));
+        _context.output.values[_key] = move(_value);
+    };
+
+    void parseOptionList(ParseContext& _context)
+    {
+        // Option := Option*
+        auto const optionPrefix = namePrefix(_context);
+
+        while (true)
+        {
+            auto optionOptPair = tryParseOption(_context);
+            if (!optionOptPair.has_value())
+                break;
+
+            auto& [option, value] = optionOptPair.value();
+            auto const fqdn = optionPrefix + "." + Name(option->name);
+            setOption(_context, fqdn, move(value));
+        }
+    }
+
+    auto tryLookupCommand(ParseContext const& _context) -> Command const*
+    {
+        auto const token = matchPrefix(currentToken(_context), "--")
+                         ? currentToken(_context).substr(2)
+                         : currentToken(_context);
+
+        for (Command const& command : _context.currentCommand.back()->children)
+        {
+            if (token == command.name)
+                return &command;
+        }
+
+        return nullptr; // not found
+    }
+
+    auto tryImplicitCommand(ParseContext const& _context) -> Command const*
+    {
+        for (Command const& command: _context.currentCommand.back()->children)
+            if (command.select == CommandSelect::Implicit)
+            {
+                CLI_DEBUG(fmt::format("Select implicit command {}.", command.name));
+                return &command;
+            }
+
+        return nullptr;
+    }
+
+    void prefillDefaults(ParseContext& _context, Command const& _command)
+    {
+        auto const _commandScope = ScopedCommand{_context, _command};
+        auto const prefix = namePrefix(_context) + ".";
+
+        for (Option const& option : _context.currentCommand.back()->options)
+        {
+            if (option.presence == Presence::Required)
+                continue; // Do not prefill options that are required anyways.
+
+            auto const fqdn = prefix + Name(option.name);
+            _context.output.values[fqdn] = option.value;
+            setOption(_context, fqdn, option.value);
+        }
+
+        for (Command const& _subcmd : _command.children)
+        {
+            auto const fqdn = prefix + Name(_subcmd.name);
+            setOption(_context, fqdn, Value{false});
+
+            prefillDefaults(_context, _subcmd);
+        }
+    }
+
+    auto parseCommand(Command const& _command, ParseContext& _context) -> bool
+    {
+        // Command := NAME Option* Section*
+        auto const _commandScope = ScopedCommand{_context, _command};
+
+        parseOptionList(_context);
+
+        if (Command const* subcmd = tryLookupCommand(_context))
+        {
+            CLI_DEBUG(fmt::format("parseCommand: found sub command: {}", subcmd->name));
+            consumeToken(_context); // Name was already ensured to be right (or is assumed to be right).
+            parseCommand(*subcmd, _context);
+        }
+        else if (Command const* subcmd = tryImplicitCommand(_context))
+        {
+            CLI_DEBUG(fmt::format("parseCommand: found implicit sub command: {}", subcmd->name));
+            // DO not consume token
+            parseCommand(*subcmd, _context);
+        }
+        else if (_command.verbatim.has_value())
+        {
+            CLI_DEBUG(fmt::format("parseCommand: going verbatim."));
+            while (_context.pos < _context.args.size())
+                _context.output.verbatim.emplace_back(consumeToken(_context));
+        }
+
+        if (_context.pos == _context.args.size())
+            _context.output.values[namePrefix(_context)] = Value{true};
+
+        // A command must not leave any trailing tokens at the end of parsing
+        return _context.pos == _context.args.size();
+    }
+
+    StringViewList stringViewList(int argc, char const * const * _argv)
+    {
+        StringViewList output;
+        output.resize(argc);
+
+        for (auto const i : times(argc))
+            output[i] = _argv[i];
+
+        return output;
+    }
+} // }}}
+
+void validate(Command const& _command)
+{
+    (void) _command;
+    // TODO: throw if Command is not well defined.
+    //
+    // - no duplicated nems in same scope
+    // - names must not start with '-' (dash)
+    // - must not contain '='
+}
+
+void validate(Command const& _command, ParseContext& _context, string const& _keyPrefix)
+{
+    auto const key = _keyPrefix.empty() ? string(_command.name)
+                                        : fmt::format("{}.{}", _keyPrefix, _command.name);
+
+    // Ensure all required fields are provided for those commands that have been provided.
+    for (Option const& option: _command.options)
+    {
+        auto const optionKey = fmt::format("{}.{}", key, option.name);
+        if (option.presence == Presence::Required && !_context.output.values.count(optionKey))
+            throw invalid_argument(fmt::format("Missing option: {}", optionKey));
+    }
+
+    for (Command const& subcmd: _command.children)
+    {
+        auto const commandKey  = fmt::format("{}.{}", key, subcmd.name);
+        if (_context.output.get<bool>(commandKey))
+            validate(subcmd, _context, key);
+    }
+}
+
+optional<FlagStore> parse(Command const& _command, StringViewList const& _args)
+{
+    validate(_command);
+
+    auto context = ParseContext{ _args };
+
+    prefillDefaults(context, _command);
+
+    // XXX do not enforce checking the first token, as for main()'s argv[0] this most likely is different.
+    // if (currentToken(context) != _command.name)
+    //     return nullopt;
+
+    consumeToken(context); // Name was already ensured to be right (or is assumed to be right).
+    if (!parseCommand(_command, context))
+        return nullopt;
+
+    // auto const& flags = context.output;
+    // std::cout << fmt::format("Flags: {}\n", flags.values.size());
+    // for (auto const & [k, v] : flags.values)
+    //     std::cout << fmt::format(" - {}: {}\n", k, v);
+
+    validate(_command, context, "");
+
+    return move(context.output);
+}
+
+optional<FlagStore> parse(Command const& _command, int _argc, char const* const* _argv)
+{
+    return parse(_command, stringViewList(_argc, _argv));
+}
+
+} // }}}
+namespace crispy::cli // {{{ Help output
+{
+
+namespace // {{{ helpers
+{
+    string spaces(int _count)
+    {
+        return string(_count, ' ');
+    }
+
+    string indent(int _level, int* _cursor = nullptr)
+    {
+        auto constexpr TabWidth = 4;
+
+        if (_cursor)
+            *_cursor += _level * TabWidth;
+
+        return spaces(_level * TabWidth);
+    }
+
+    // TODO: this and OSC-8 (hyperlinks)
+    auto stylizer(HelpStyle const& _style) -> function<string(string_view, HelpElement)>
+    {
+        return [_style](string_view _text, HelpElement _element) -> string {
+            auto const [pre, post] = [&]() -> pair<string_view, string_view> {
+                if (_style.colors.has_value() && _style.colors.value().count(_element))
+                    return {_style.colors.value().at(_element), "\033[m"sv};
+                else
+                    return {""sv, ""sv};
+            }();
+
+            if (!_style.hyperlink)
+                return fmt::format("{}{}{}", pre, _text, post);
+
+            string output;
+            size_t a = 0;
+            for (;;)
+            {
+                size_t const b = _text.find("://", a);
+                if (b == _text.npos || !b)
+                    break;
+
+                size_t left = b;
+                while (left > 0 && isalpha(_text.at(left - 1)))
+                    --left;
+
+                size_t right = b + 3;
+                while (right < _text.size() && _text.at(right) != ' ')
+                    right++;
+
+                output += pre;
+                output += _text.substr(a, left - a);
+                output += post;
+
+                output += "\033]8;;";
+                output += _text.substr(left, right - left);
+                output += "\033\\";
+
+                output += _text.substr(left, right - left);
+
+                output += "\033]8;;\033\\";
+
+                a = right;
+            }
+            output += pre;
+            output += _text.substr(a);
+            output += post;
+
+            return output;
+        };
+    }
+
+    auto colorizer(optional<HelpStyle::ColorMap> const& _colors) -> function<string(string_view, HelpElement)>
+    {
+        HelpStyle style{};
+        style.colors = _colors;
+        return stylizer(style);
+    }
+
+    string_view wordWrapped(string_view _text, int _margin, int _cursor)
+    {
+        auto const unwrappedLength = _cursor + int(_text.size());
+        if (unwrappedLength <= _margin)
+            return _text;
+
+        // Cut string at right margin, then shift left until we've hit a whitespace character.
+        auto i = _margin - _cursor + 1;
+        while (i > 0 && _text[i] != ' ')
+            --i;
+
+        return _text.substr(0, i);
+    }
+
+    string wordWrapped(string_view _text, int _indent, int _margin, int* _cursor)
+    {
+        string output;
+        size_t i = 0;
+        for (;;)
+        {
+            while (i < _text.size() && _text[i] == ' ')
+                ++i; // skip leading whitespaces
+
+            auto const chunk = wordWrapped(_text.substr(i), _margin, *_cursor);
+
+            output += chunk;
+            *_cursor += chunk.size();
+            i += chunk.size();
+
+            if (i == _text.size())
+                break;
+
+            output += '\n';
+            output += spaces(_indent);
+            *_cursor = _indent + 1;
+        }
+        return output;
+    }
+
+    string printParam(optional<HelpStyle::ColorMap> const& _colors,
+                      OptionStyle _optionStyle,
+                      string_view _name,
+                      string const& _placeholder,
+                      Presence _presense)
+    {
+        auto const colorize = colorizer(_colors);
+
+        stringstream os;
+
+        if (_presense == Presence::Optional)
+            os << colorize("[", HelpElement::Braces);
+        switch (_optionStyle)
+        {
+            case OptionStyle::Natural:
+                os << colorize(_name, HelpElement::OptionName);
+                if (!_placeholder.empty())
+                    os << ' ' << colorize(_placeholder, HelpElement::OptionValue);
+                break;
+            case OptionStyle::Posix:
+                os << colorize("--", HelpElement::OptionDash) << colorize(_name, HelpElement::OptionName);
+                if (!_placeholder.empty())
+                    os << colorize("=", HelpElement::OptionEqual) << colorize(_placeholder, HelpElement::OptionValue);
+                break;
+        }
+        if (_presense == Presence::Optional)
+            os << colorize("]", HelpElement::Braces);
+
+        return os.str();
+    }
+
+    string printOption(Option const& _option,
+                       optional<HelpStyle::ColorMap> const& _colors,
+                       OptionStyle _optionStyle)
+    {
+        // TODO: make use of _option.placeholder
+        if (holds_alternative<bool>(_option.value))
+            return printParam(_colors, _optionStyle, _option.name, "", _option.presence);
+        else if (holds_alternative<int>(_option.value))
+            return printParam(_colors, _optionStyle, _option.name, "INT", _option.presence);
+        else if (holds_alternative<unsigned int>(_option.value))
+            return printParam(_colors, _optionStyle, _option.name, "UINT", _option.presence);
+        else if (holds_alternative<double>(_option.value))
+            return printParam(_colors, _optionStyle, _option.name, "FLOAT", _option.presence);
+        else
+            return printParam(_colors, _optionStyle, _option.name, "STRING", _option.presence);
+    }
+
+    string printOption(Option const& _option,
+                       optional<HelpStyle::ColorMap> const& _colors,
+                       OptionStyle _displayStyle,
+                       int _indent, int _margin, int* _cursor)
+    {
+        auto const plainTextLength = int(printOption(_option, nullopt, _displayStyle).size());
+        if (*_cursor + plainTextLength < _margin)
+        {
+            *_cursor += plainTextLength;
+            return printOption(_option, _colors, _displayStyle);
+        }
+        else
+        {
+            *_cursor = _indent + 1 + plainTextLength;
+            return "\n" + spaces(_indent) + printOption(_option, _colors, _displayStyle);
+        }
+    }
+
+    size_t longestOptionText(OptionList const& _options, OptionStyle _displayStyle)
+    {
+        size_t result = 0;
+        for (Option const& option : _options)
+            result = max(result, printOption(option, nullopt, _displayStyle).size());
+        return result;
+    }
+
+    void detailedDescription(ostream& _os, Command const& _command,
+                             HelpStyle const& _style, int _margin, vector<Command const*>& _parents)
+    {
+        // NOTE: We asume that cursor position is at first column!
+        auto const stylize = stylizer(_style);
+        bool const isSubCommand = !_parents.empty();
+
+        if (isSubCommand || !_command.options.empty() || _command.verbatim.has_value()) // {{{ print command sequence
+        {
+            _os << indent(1);
+            for (Command const* parent : _parents)
+                _os << stylize(parent->name, HelpElement::OptionValue/*well, yeah*/) << ' ';
+
+            if (_command.select == CommandSelect::Explicit)
+                _os << _command.name;
+            else
+            {
+                _os << stylize("[", HelpElement::Braces);
+                _os << stylize(_command.name, HelpElement::ImplicitCommand);
+                _os << stylize("]", HelpElement::Braces);
+            }
+
+            _os << "\n";
+
+            if (isSubCommand)
+            {
+                int cursor = 1;
+                _os << indent(2, &cursor);
+                _os << stylize(wordWrapped(_command.helpText, cursor, _margin, &cursor), HelpElement::HelpText) << "\n\n";
+            }
+        }
+        // }}}
+        if (!_command.options.empty() || _command.verbatim.has_value()) // {{{ print options
+        {
+            _os << indent(2) << stylize("Options:", HelpElement::Header) << "\n\n";
+
+            auto const leftPadding = indent(3);
+            auto const minRightPadSize = 2;
+            auto const maxOptionTextSize = longestOptionText(_command.options, _style.optionStyle);
+            auto const columnWidth = leftPadding.size() + maxOptionTextSize + minRightPadSize;
+
+            for (Option const& option : _command.options)
+            {
+                auto const leftSize = leftPadding.size() + printOption(option, nullopt, _style.optionStyle).size();
+                auto const actualRightPaddingSize = int(columnWidth) - int(leftSize);
+                auto const left = leftPadding + printOption(option, _style.colors, _style.optionStyle) + spaces(actualRightPaddingSize);
+
+                _os << left;
+
+                int cursor = int(columnWidth) + 1;
+                _os << stylize(wordWrapped(option.helpText, columnWidth, _margin, &cursor), HelpElement::HelpText);
+
+                // {{{ append default value, if any
+                auto const defaultValueStr = fmt::format("{}", option.value);
+                if ((option.presence == Presence::Optional && !defaultValueStr.empty())
+                    || (holds_alternative<bool>(option.value) && get<bool>(option.value)))
+                {
+                    auto const DefaultTextPrefix = string("default:");
+                    auto const defaultText = stylize("[", HelpElement::Braces)
+                                           + DefaultTextPrefix + " "
+                                           + stylize(defaultValueStr, HelpElement::OptionValue)
+                                           + stylize("]", HelpElement::Braces);
+                    auto const defaultTextLength = int(1 + DefaultTextPrefix.size() + 1 + defaultValueStr.size() + 1);
+                    if (cursor + defaultTextLength > _margin)
+                        _os << "\n" << spaces(columnWidth) << defaultText;
+                    else
+                        _os << " " << defaultText;
+                }
+                // }}}
+
+                _os << '\n';
+            }
+            if (_command.verbatim.has_value())
+            {
+                auto const& verbatim = _command.verbatim.value();
+                auto const leftSize = leftPadding.size() + 2 + verbatim.placeholder.size();
+                auto const actualRightPaddingSize = int(columnWidth) - int(leftSize);
+                auto const left = leftPadding
+                    + stylize("[", HelpElement::Braces)
+                    + stylize(verbatim.placeholder, HelpElement::Verbatim)
+                    + stylize("]", HelpElement::Braces)
+                    + spaces(actualRightPaddingSize);
+
+                _os << left;
+                int cursor = int(columnWidth) + 1;
+                _os << stylize(wordWrapped(verbatim.helpText, columnWidth, _margin, &cursor), HelpElement::HelpText);
+                _os << '\n';
+            }
+            _os << '\n';
+        }
+        // }}}
+        if (!_command.children.empty()) // {{{ recurse to sub commands
+        {
+            _parents.emplace_back(&_command);
+            for (Command const& subcmd : _command.children)
+                detailedDescription(_os, subcmd, _style, _margin, _parents);
+            _parents.pop_back();
+        } // }}}
+    }
+
+    void detailedDescription(ostream& _os, Command const& _command, HelpStyle const& _style, int _margin)
+    {
+        vector<Command const*> parents;
+        detailedDescription(_os, _command, _style, _margin, parents);
+    }
+} // }}}
+
+HelpStyle::ColorMap HelpStyle::defaultColors()
+{
+    return ColorMap{
+        {HelpElement::Header, "\033[32;1;4:2m"},
+        {HelpElement::Braces, "\033[37;1m"},
+        {HelpElement::OptionDash, "\033[34;1m"},
+        {HelpElement::OptionName, "\033[37m"},
+        {HelpElement::OptionEqual, "\033[34;1m"},
+        {HelpElement::OptionValue, "\033[36m"},
+        {HelpElement::ImplicitCommand, "\033[33;1m"},
+        {HelpElement::Verbatim, "\033[36m"},
+        {HelpElement::HelpText, "\033[38m"},
+    };
+}
+
+/**
+ * Constructs a usage text suitable for printing out the command usage syntax in terminals.
+ *
+ * @param _command The command to construct the usage text for.
+ * @param _colored Boolean indicating whether or not to colorize the output via VT sequences.
+ * @param _margin  Number of characters to write at most per line.
+ */
+string usageText(Command const& _command, HelpStyle const& _style, int _margin, string const& _cmdPrefix)
+{
+    auto const colorize = colorizer(_style.colors);
+    auto const indentationWidth = int(_cmdPrefix.size());
+
+    auto const printOptionList = [&](ostream& _os, OptionList const& _options, int* _cursor)
+    {
+        auto const indent = *_cursor;
+        for (Option const& option : _options)
+            _os << ' ' << printOption(option, _style.colors, _style.optionStyle,
+                                      indent, _margin, _cursor);
+    };
+
+    auto cursor = indentationWidth + 1;
+    if (_command.children.empty())
+    {
+        stringstream sstr;
+        sstr << _cmdPrefix;
+
+        if (_command.select == CommandSelect::Explicit)
+        {
+            cursor += _command.name.size();
+            sstr << _command.name;
+        }
+        else
+        {
+            cursor += _command.name.size() + 2;
+            sstr << colorize("[", HelpElement::Braces);
+            sstr << colorize(_command.name, HelpElement::ImplicitCommand);
+            sstr << colorize("]", HelpElement::Braces);
+        }
+
+        auto const indent = cursor;
+        printOptionList(sstr, _command.options, &cursor);
+
+        if (_command.verbatim.has_value())
+        {
+            if (cursor + 3 + _command.verbatim.value().placeholder.size() > size_t(_margin))
+            {
+                sstr << "\n";
+                sstr << spaces(indent);
+            }
+            else
+                sstr << ' ';
+
+            sstr << colorize("[", HelpElement::Braces);
+            sstr << colorize(_command.verbatim.value().placeholder, HelpElement::Verbatim);
+            sstr << colorize("]", HelpElement::Braces);
+        }
+
+        sstr << '\n';
+        return sstr.str();
+    }
+    else
+    {
+        stringstream prefix;
+        prefix << _cmdPrefix << _command.name;
+        printOptionList(prefix, _command.options, &cursor);
+        prefix << ' ';
+
+        string const prefixStr = prefix.str();
+        stringstream sstr;
+        for (Command const& subcmd : _command.children)
+            sstr << usageText(subcmd, _style, _margin, prefixStr);
+        sstr << '\n';
+        return sstr.str();
+    }
+}
+
+string helpText(Command const& _command, HelpStyle const& _style, int _margin)
+{
+    auto const stylize = stylizer(_style);
+
+    stringstream output;
+
+    output << stylize(_command.helpText, HelpElement::HelpText) << "\n\n";
+
+    output << "  " << stylize("Usage:", HelpElement::Header) << "\n\n";
+    output << usageText(_command, _style, _margin, indent(1));
+
+    auto constexpr DescriptionHeader = string_view{"Detailed description:"};
+
+    output << "  " << stylize(DescriptionHeader, HelpElement::Header) << "\n\n";
+    detailedDescription(output, _command, _style, _margin);
+
+    return output.str();
+}
+
+} // }}}

--- a/src/crispy/CLI.h
+++ b/src/crispy/CLI.h
@@ -1,0 +1,196 @@
+/**
+ * This file is part of the "libterminal" project
+ *   Copyright (c) 2019-2020 Christian Parpart <christian@parpart.family>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <fmt/format.h>
+
+#include <map>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace crispy::cli
+{
+
+using Value = std::variant<int, unsigned int, std::string, double, bool>;
+using Name = std::string;
+
+enum class Presence
+{
+    Optional,
+    Required,
+};
+
+struct Option
+{
+    std::string_view name;
+    Value value;
+    std::string_view helpText = {};
+    std::string_view placeholder = {}; // TODO: move right below `Value value{};`
+    Presence presence = Presence::Optional;
+};
+
+using OptionList = std::vector<Option>;
+
+enum class CommandSelect
+{
+    Explicit,
+    Implicit, // only one command at a scope level can be implicit
+};
+
+struct Verbatim
+{
+    std::string placeholder;
+    std::string helpText;
+};
+
+struct Command;
+using CommandList = std::vector<Command>;
+
+struct Command
+{
+    std::string_view name;
+    std::string_view helpText = {};
+    OptionList options = {};
+    //std::vector<Command> children = {};
+    CommandList children = {};
+    CommandSelect select = CommandSelect::Explicit;
+    std::optional<Verbatim> verbatim = {}; // Unly allowed if no sub commands were specified.
+};
+
+using CommandList = std::vector<Command>;
+
+enum class OptionStyle
+{
+    Natural,
+    Posix,
+};
+
+class ParserError : public std::runtime_error
+{
+   public:
+    explicit ParserError(std::string const& _msg) : std::runtime_error(_msg) {}
+};
+
+struct FlagStore
+{
+    std::map<Name, Value> values;
+    std::vector<std::string_view> verbatim;
+
+    bool boolean(std::string const& _key) const { return std::get<bool>(values.at(_key)); }
+    int integer(std::string const& _key) const { return std::get<int>(values.at(_key)); }
+    unsigned uint(std::string const& _key) const { return std::get<unsigned>(values.at(_key)); }
+    double real(std::string const& _key) const { return std::get<double>(values.at(_key)); }
+    std::string const& str(std::string const& _key) const { return std::get<std::string>(values.at(_key)); }
+
+    template <typename T> T get(std::string const& _key) const { return std::get<T>(values.at(_key)); }
+};
+
+/*
+ * Validates @p _command to be well-formed and throws an exception otherwise.
+ */
+// TODO: void validate(Command const& _command);
+
+using StringViewList = std::vector<std::string_view>;
+
+/**
+ * Parses the command line arguments with respect to @p _command as passed via @p _args.
+ *
+ * @returns a @c FlagStore containing the parsed result or std::nullopt on failure.
+ */
+std::optional<FlagStore> parse(Command const& _command, StringViewList const& _args);
+
+/**
+ * Parses the command line arguments with respect to @p _command as passed via (_argc, _argv) suitable
+ * for a general main() functions's argc and argv.
+ *
+ * @returns a @c FlagStore containing the parsed result or std::nullopt on failure.
+ */
+std::optional<FlagStore> parse(Command const& _command, int _argc, char const* const* _argv);
+
+enum class HelpElement
+{
+    Header,
+    Braces,
+    OptionDash,
+    OptionName,
+    OptionEqual,
+    OptionValue,
+    ImplicitCommand,
+    Verbatim,
+    HelpText
+};
+
+struct HelpStyle // TODO: maybe call HelpDisplayStyle?
+{
+    using ColorMap = std::map<HelpElement, std::string>;
+    static ColorMap defaultColors();
+
+    std::optional<ColorMap> colors = defaultColors();
+    bool hyperlink = true;   // whether or not to enable OSC 8 (Hyperlink).
+    OptionStyle optionStyle = OptionStyle::Natural;
+};
+
+/**
+ * Constructs a usage text suitable for printing out the command usage syntax in terminals.
+ *
+ * @param _command      The command to construct the usage text for.
+ * @param _style        Determines how to format and colorize the output string.
+ * @param _margin       Number of characters to write at most per line.
+ * @param _cmdPrefix    Some text to prepend in front of each generated line in the output.
+ */
+std::string usageText(Command const& _command, HelpStyle const& _style, int _margin,
+                      std::string const& _cmdPrefix = {});
+
+/**
+ * Constructs a help text suitable for printing out the command usage syntax in terminals.
+ *
+ * @param _command      The command to construct the usage text for.
+ * @param _style        Determines how to format and colorize the output string.
+ * @param _margin       Number of characters to write at most per line.
+ */
+std::string helpText(Command const& _command, HelpStyle const& _style, int _margin);
+
+} // end namespace crispy::cli
+
+namespace fmt // {{{ type formatters
+{
+    template <>
+    struct formatter<crispy::cli::Value> {
+        template <typename ParseContext>
+        constexpr auto parse(ParseContext& ctx) { return ctx.begin(); }
+        template <typename FormatContext>
+        auto format(crispy::cli::Value const& _value, FormatContext& ctx)
+        {
+            if (std::holds_alternative<bool>(_value))
+                return format_to(ctx.out(), "{}", std::get<bool>(_value));
+            else if (std::holds_alternative<int>(_value))
+                return format_to(ctx.out(), "{}", std::get<int>(_value));
+            else if (std::holds_alternative<unsigned>(_value))
+                return format_to(ctx.out(), "{}", std::get<unsigned>(_value));
+            else if (std::holds_alternative<double>(_value))
+                return format_to(ctx.out(), "{}", std::get<double>(_value));
+            else if (std::holds_alternative<std::string>(_value))
+                return format_to(ctx.out(), "{}", std::get<std::string>(_value));
+            else
+                return format_to(ctx.out(), "?");
+            //return format_to(ctx.out(), "{}..{}", range.from, range.to);
+        }
+    };
+} // }}}

--- a/src/crispy/CLI_test.cpp
+++ b/src/crispy/CLI_test.cpp
@@ -1,0 +1,133 @@
+/**
+ * This file is part of the "libterminal" project
+ *   Copyright (c) 2019-2020 Christian Parpart <christian@parpart.family>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <crispy/CLI.h>
+#include <fmt/format.h>
+#include <catch2/catch.hpp>
+
+// TODO API / impl:
+//
+// - [ ] int-casts in cli.h are a nightmare. use size_t when applicable then.
+// - [ ] Add ValueDef { Value defaultValue; std::string_view placeholder; } and use this where Value{} was used.
+// - [x] option presence validation (optional, required)
+// - [x] option variation parsing: posix
+// - [x] usage output
+// - [x] help output
+// - [x] colorizing the output for usage and detailed help
+// - [x] easy accessor for flag values
+// - [x] line/word-wrapping; smart indentation at the beginning of the text scope
+// - [x] help output: print default, if available (i.e. presence=optional)
+
+// TODO tests:
+//
+// - [ ] variations of option names and value attachements
+//       all of: NAME [VALUE] | --NAME [VALUE] | -NAME [VALUE] | --NAME[=VALUE]
+// - [ ] help output printing (colored, non-colored)
+// - [ ] help output auto-detecting screen width, via: VT seq, ioctl(TIOCGWINSZ), manual
+// - [ ] presence optional vs presence required
+// - [x] test option type: BOOL
+// - [ ] test option type: INT
+// - [ ] test option type: UINT
+// - [ ] test option type: FLOAT (also being passed as INT positive / negative)
+// - [ ] test option type: STR (can be any arbitrary string)
+// - [ ] test option defaults
+// - [ ] CONSIDER: supporting positional arguments (free sanding values of single given type)
+// - [ ] test command chains up to 3 levels deep (including proper help output, maybe via /bin/ip emul?)
+//
+
+using std::optional;
+using std::string;
+
+namespace cli = crispy::cli;
+
+using namespace std::string_view_literals;
+using namespace std::string_literals;
+
+TEST_CASE("CLI.option.type.bool")
+{
+    auto const cmd = cli::Command{
+        "contour",
+        "help here",
+        cli::OptionList{
+            cli::Option{"verbose"sv, cli::Value{false}, "Help text here"sv}
+        },
+    };
+
+    SECTION("set") {
+        auto const args = cli::StringViewList{"contour", "verbose"};
+        optional<cli::FlagStore> const flagsOpt = cli::parse(cmd, args);
+        REQUIRE(flagsOpt.has_value());
+        CHECK(flagsOpt.value().values.at("contour.verbose") == cli::Value{true});
+    }
+
+    SECTION("set true") {
+        auto const args = cli::StringViewList{"contour", "verbose", "true"};
+        optional<cli::FlagStore> const flagsOpt = cli::parse(cmd, args);
+        REQUIRE(flagsOpt.has_value());
+        CHECK(flagsOpt.value().values.at("contour.verbose") == cli::Value{true});
+    }
+
+    SECTION("set true") {
+        auto const args = cli::StringViewList{"contour", "verbose", "false"};
+        optional<cli::FlagStore> const flagsOpt = cli::parse(cmd, args);
+        REQUIRE(flagsOpt.has_value());
+        CHECK(flagsOpt.value().values.at("contour.verbose") == cli::Value{false});
+    }
+
+    SECTION("unset") {
+        auto const args = cli::StringViewList{"contour"};
+        optional<cli::FlagStore> const flagsOpt = cli::parse(cmd, args);
+        REQUIRE(flagsOpt.has_value());
+        CHECK(flagsOpt.value().values.at("contour.verbose") == cli::Value{false});
+    }
+}
+
+TEST_CASE("CLI.contour-full-test")
+{
+    auto const cmd = cli::Command{
+        "contour",
+        "help here",
+        cli::OptionList{
+            cli::Option{"debug"sv, cli::Value{""s}, "Help text here"sv},
+            cli::Option{"config", cli::Value{"~/.config/contour/contour.yml"s}, "Help text there"sv},
+            cli::Option{"profile", cli::Value{""s}, "Help text over here"sv}
+        },
+        cli::CommandList{
+            cli::Command{
+                "capture",
+                "some capture help text",
+                {
+                    cli::Option{"logical", cli::Value{false}, "help there"},
+                    cli::Option{"timeout", cli::Value{1.0}, "help here"},
+                    cli::Option{"output", cli::Value{""s}},
+                }
+            }
+        }
+    };
+
+    auto const args = cli::StringViewList{"contour", "capture", "logical", "output", "out.vt"};
+    optional<cli::FlagStore> const flagsOpt = cli::parse(cmd, args);
+    REQUIRE(flagsOpt.has_value());
+
+    cli::FlagStore const& flags = flagsOpt.value();
+
+    CHECK(flags.values.size() == 8);
+    CHECK(flags.values.at("contour") == cli::Value{true}); // command
+    CHECK(flags.values.at("contour.debug") == cli::Value{""s});
+    CHECK(flags.values.at("contour.config") == cli::Value{"~/.config/contour/contour.yml"s});
+    CHECK(flags.values.at("contour.profile") == cli::Value{""s});
+    CHECK(flags.values.at("contour.capture") == cli::Value{true}); // command
+    CHECK(flags.values.at("contour.capture.logical") == cli::Value{true});
+    CHECK(flags.values.at("contour.capture.output") == cli::Value{"out.vt"s});
+    CHECK(flags.values.at("contour.capture.timeout") == cli::Value{1.0});
+}

--- a/src/crispy/CMakeLists.txt
+++ b/src/crispy/CMakeLists.txt
@@ -3,36 +3,38 @@ include("${CMAKE_CURRENT_LIST_DIR}/../../cmake/FilesystemResolver.cmake")
 # --------------------------------------------------------------------------------------------------------
 # crispy::core
 
-add_library(crispy-core INTERFACE)
+set(crispy_SOURCES
+    CLI.h CLI.cpp
+    Comparison.h
+    algorithm.h
+    base64.h
+    compose.h
+    debuglog.h
+    escape.h
+    indexed.h
+    overloaded.h
+    reference.h
+    span.h
+    stdfs.h
+    times.h
+)
+
+add_library(crispy-core ${crispy_SOURCES})
 add_library(crispy::core ALIAS crispy-core)
 
 set(CRISPY_CORE_LIBS fmt::fmt-header-only unicode::core)
 if(${USING_BOOST_FILESYSTEM})
-    target_compile_definitions(crispy-core INTERFACE USING_BOOST_FILESYSTEM=1)
+    target_compile_definitions(crispy-core PUBLIC USING_BOOST_FILESYSTEM=1)
     list(APPEND CRISPY_CORE_LIBS Boost::filesystem)
 else()
     list(APPEND CRISPY_CORE_LIBS ${FILESYSTEM_LIBS})
 endif()
 
-target_link_libraries(crispy-core INTERFACE ${CRISPY_CORE_LIBS})
-target_compile_features(crispy-core INTERFACE cxx_std_17)
-target_include_directories(crispy-core INTERFACE
+target_link_libraries(crispy-core PUBLIC ${CRISPY_CORE_LIBS})
+target_compile_features(crispy-core PUBLIC cxx_std_17)
+target_include_directories(crispy-core PUBLIC
     $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}/src>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/include>
-)
-target_sources(crispy-core INTERFACE
-    ${CMAKE_CURRENT_SOURCE_DIR}/Comparison.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/algorithm.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/base64.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/compose.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/escape.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/indexed.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/debuglog.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/overloaded.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/reference.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/span.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/stdfs.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/times.h
 )
 
 # --------------------------------------------------------------------------------------------------------
@@ -42,6 +44,7 @@ option(CRISPY_TESTING "Enables building of unittests for crispy library [default
 if(CRISPY_TESTING)
     enable_testing()
     add_executable(crispy_test
+        CLI_test.cpp
         base64_test.cpp
         indexed_test.cpp
         compose_test.cpp


### PR DESCRIPTION
- [ ] unit tests (partial)
- [ ] ~maybe support short options? (hm, maybe not. didn't find a good solution just yet)~
- [x] nested command syntax (a la iproute2)
- [x] Automatic usage and help text generation
- [x] default sub command (if command itself has no options)
- [x] alternate Option passing style; posix
- [x] help output: colorized
- [x] help output: flag the default command visually (`*`?)
- [x] help output: word wrapped
- [x] help text: description with url inside should use OSC 8 if VT sequenced output is allowed.
- [x] contour: make use of new CLI API
- [x] update README for section (syntax/usage) respectively