### PR TITLE
[Arch linux build] Disabling arm build in order to speed up the actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -303,8 +303,7 @@ jobs:
       matrix:
         arch:
           [
-            "linux/amd64 x86_64",
-            "linux/arm64/v8 aarch64",
+            "linux/amd64 x86_64"
           ]
     name: "Archlinux ${{ matrix.arch }}"
     runs-on: ubuntu-latest


### PR DESCRIPTION
Disabling arm build in order to speed up the actions since we don't need it and it takes 13mins for the arm build to
complete