### PR TITLE
[CodeChecker] Ignore external third party libraries and generated code from analysis

### DIFF
--- a/.github/codechecker_config/config.json
+++ b/.github/codechecker_config/config.json
@@ -1,0 +1,13 @@
+{
+  "analyze": [
+    "--enable=portability",
+    "--enable=security",
+    "--enable=sensitive",
+    "--disable=google",
+    "--enable=google-build-namespaces",
+    "--skip=.github/codechecker_config/skipfile.txt"
+  ],
+  "parse": [
+    "--skip=.github/codechecker_config/skipfile.txt"
+  ]
+}

--- a/.github/codechecker_config/skipfile.txt
+++ b/.github/codechecker_config/skipfile.txt
@@ -1,0 +1,4 @@
+-/usr/include/*
++*/Build/3rdparty/libunicode/*
+-*/Build/3rdparty/*
+-*/Build/src/contour/contour_autogen/*

--- a/.github/workflows/codechecker-analysis.yml
+++ b/.github/workflows/codechecker-analysis.yml
@@ -97,52 +97,54 @@ jobs:
         run: |
           "$GITHUB_WORKSPACE"/CodeChecker/build/CodeChecker/bin/CodeChecker \
             analyzers --detail
+          cat ".github/codechecker_config/config.json"
           "$GITHUB_WORKSPACE"/CodeChecker/build/CodeChecker/bin/CodeChecker \
             analyze \
-            logged_compilation.json \
+            "logged_compilation.json" \
+            --config ".github/codechecker_config/config.json" \
             --jobs $(nproc) \
             --output "Results" \
             \
-            --enable portability \
-            --enable security \
-            --enable sensitive \
-            --disable google \
-            --enable google-build-namespaces \
           || true
       - name: "Perform static analysis (CTU for pushes on master)"
         if: ${{ github.ref == 'refs/heads/master' && github.event_name == 'push' }}
         run: |
           "$GITHUB_WORKSPACE"/CodeChecker/build/CodeChecker/bin/CodeChecker \
             analyzers --detail
+          cat ".github/codechecker_config/config.json"
           "$GITHUB_WORKSPACE"/CodeChecker/build/CodeChecker/bin/CodeChecker \
             analyze \
-            logged_compilation.json \
+            "logged_compilation.json" \
+            --config ".github/codechecker_config/config.json" \
             --jobs $(nproc) \
             --output "Results" \
-            \
-            --enable portability \
-            --enable security \
-            --enable sensitive \
-            --disable google \
-            --enable google-build-namespaces \
             \
             --ctu \
             --ctu-ast-mode load-from-pch \
           || true
       - name: "Convert static analysis results to HTML"
         run: |
+          cat ".github/codechecker_config/config.json"
           "$GITHUB_WORKSPACE"/CodeChecker/build/CodeChecker/bin/CodeChecker \
             parse \
             "Results" \
+            --config ".github/codechecker_config/config.json" \
             --export html \
             --output "Results-HTML"
-      - name: "Upload results"
+      - name: "Dump analysis results to CI log"
+        run: |
+          cat ".github/codechecker_config/config.json"
+          "$GITHUB_WORKSPACE"/CodeChecker/build/CodeChecker/bin/CodeChecker \
+            parse \
+            "Results" \
+            --config ".github/codechecker_config/config.json"
+      - name: "Upload HTML results"
         uses: actions/upload-artifact@v2
         with:
           name: "CodeChecker Results"
           path: "Results-HTML"
           if-no-files-found: error
-      - name: "Upload analysis failure reproducers"
+      - name: "Upload analysis failure collections"
         uses: actions/upload-artifact@v2
         with:
           name: "CodeChecker analysis failures"


### PR DESCRIPTION
The following improvements were made:

 * Put the common configuration of the analysis into a dedicated config file to deduplicate parts of the CI.
 * Ignore external code sources, like `Build/3rdparty` and `/usr/include` from the analysis.
    * TUs (CPP files) that are in these paths will not be invoked the analysis for, at all.
    * AFAIK (but I might be wrong in this), analysis findings that are reported to files in these directories (e.g. headers in `/usr/include`) will be culled from the analysis. This might be detrimental in case a bogus usage of the STL starts from a core Contour TU but the "null dereference" is in the STL or something like that. Will have to see where this leads us...
 * Added a new action in the CI that shows the result summary to the CI standard output itself