### PR TITLE
[CI] CodeChecker: Fix build breaking due to exit status signalling "reports found"

### DIFF
--- a/.github/workflows/codechecker-analysis.yml
+++ b/.github/workflows/codechecker-analysis.yml
@@ -130,7 +130,6 @@ jobs:
             --config "$CODECHECKER_CONFIG" \
             --jobs $(nproc) \
             --output "Results" \
-            \
           || true
       - name: "Perform static analysis (CTU for pushes on master)"
         if: ${{ github.ref == 'refs/heads/master' && github.event_name == 'push' }}
@@ -156,11 +155,14 @@ jobs:
             --export html \
             --output "Results-HTML"
       - name: "Dump analysis results to CI log"
+        # Ignore the exit status of the parse command - the fact that we have
+        # reports will be obvious from the arfect and the CI output.
         run: |
           "${{ steps.codechecker.outputs.CODECHECKER_PATH }}"/CodeChecker \
             parse \
             "Results" \
-            --config "$CODECHECKER_CONFIG"
+            --config "$CODECHECKER_CONFIG" \
+          || true
       - name: "Upload HTML results"
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
Originally, it was the `analyze` command which signalled through the exit status that _"some reports were found"_. Now, Ericsson/CodeChecker#3232 *moved* this weirdness to the `parse` command.

CI script pulled after that, now we're also ignoring the exit status of the `parse` command. Hopefully this will make it so that the analysis artefacts are collected properly...