### PR TITLE
[contour] Changes CLI parameters `output` to `to` in all cases except for capture command.

### DIFF
--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -18,6 +18,7 @@
 # 3.) /Changelog.md with the first line's version number and optional (suffix) string
 #
 function(GetVersionInformation VersionTripleVar VersionStringVar)
+    # 1.) /version.txt file
     if(EXISTS "${CMAKE_SOURCE_DIR}/version.txt")
         file(READ "${CMAKE_SOURCE_DIR}/version.txt" version_text)
         string(STRIP "${version_text}" version_text)
@@ -27,6 +28,7 @@ function(GetVersionInformation VersionTripleVar VersionStringVar)
         set(THE_SOURCE "${CMAKE_SOURCE_DIR}/version.txt")
     endif()
 
+    # 2.) /.git directory with the output of `git describe ...`)
     if(("${THE_VERSION}" STREQUAL "" OR "${THE_VERSION_STRING}" STREQUAL "") AND (EXISTS "${CMAKE_SOURCE_DIR}/.git"))
         execute_process(COMMAND git describe --all
             OUTPUT_VARIABLE git_branch
@@ -58,6 +60,7 @@ function(GetVersionInformation VersionTripleVar VersionStringVar)
         set(THE_SOURCE "git & ${CMAKE_SOURCE_DIR}/Changelog.md")
     endif()
 
+    # 3.) /Changelog.md with the first line's version number and optional (suffix) string
     if(("${THE_VERSION}" STREQUAL "" OR "${THE_VERSION_STRING}" STREQUAL "") AND (EXISTS "${CMAKE_SOURCE_DIR}/Changelog.md"))
         file(READ "${CMAKE_SOURCE_DIR}/Changelog.md" changelog_contents)
         # extract and construct version triple

--- a/scripts/release-ppa.sh
+++ b/scripts/release-ppa.sh
@@ -53,6 +53,10 @@ function main()
     cmake -D3rdparty_DOWNLOAD_DIR="${DISTDIR}" -B "${BINDIR}" -S "${SRCDIR}"
     cp -rvp "${DISTDIR}" "${SRCDIR}/_3rdparty"
 
+    # Also preserve the expected version information, because
+    # the Ubuntu PPA server's won't have git information anymore.
+    cp -vp "${BINDIR}/version.txt" "${SRCDIR}"
+
     einfo "Prepare source tarball."
     local debversion="$VERSION~develop-$COMMIT_DATE-$COMMIT_HASH"
     local TARFILE="../contour_${debversion}.orig.tar.gz"

--- a/src/contour/CMakeLists.txt
+++ b/src/contour/CMakeLists.txt
@@ -135,7 +135,7 @@ if(NOT(WIN32))
     add_custom_command(
         TARGET contour POST_BUILD
         WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
-        COMMAND contour generate terminfo output ${terminfo_file} && ${TIC} -x -o "${terminfo_basedir}" "${terminfo_file}"
+        COMMAND ${CMAKE_CURRENT_BINARY_DIR}/contour generate terminfo to ${terminfo_file} && ${TIC} -x -o "${terminfo_basedir}" "${terminfo_file}"
         DEPENDS "${terminfo_file}"
         COMMENT "Compiling ${terminfo_file}"
         BYPRODUCTS "${terminfo_file}"

--- a/src/contour/ContourApp.cpp
+++ b/src/contour/ContourApp.cpp
@@ -70,7 +70,7 @@ auto withOutput(crispy::cli::FlagStore const& _flags, std::string const& _name, 
 
 int ContourApp::integrationAction()
 {
-    return withOutput(parameters(), "contour.generate.integration.output", [&](auto& _stream) {
+    return withOutput(parameters(), "contour.generate.integration.to", [&](auto& _stream) {
         auto const shell = parameters().get<string>("contour.generate.integration.shell");
         if (shell == "zsh")
         {
@@ -87,7 +87,7 @@ int ContourApp::integrationAction()
 
 int ContourApp::configAction()
 {
-    withOutput(parameters(), "contour.generate.config.output", [](auto& _stream) {
+    withOutput(parameters(), "contour.generate.config.to", [](auto& _stream) {
         _stream << config::createDefaultConfig();
     });
     return EXIT_SUCCESS;
@@ -95,7 +95,7 @@ int ContourApp::configAction()
 
 int ContourApp::terminfoAction()
 {
-    withOutput(parameters(), "contour.generate.terminfo.output", [](auto& _stream) {
+    withOutput(parameters(), "contour.generate.terminfo.to", [](auto& _stream) {
         _stream << terminal::capabilities::StaticDatabase{}.terminfo();
     });
     return EXIT_SUCCESS;
@@ -107,7 +107,7 @@ int ContourApp::captureAction()
     captureSettings.logicalLines = parameters().get<bool>("contour.capture.logical");
     captureSettings.timeout = parameters().get<double>("contour.capture.timeout");
     captureSettings.lineCount = parameters().get<unsigned>("contour.capture.lines");
-    captureSettings.outputFile = parameters().get<string>("contour.capture.output");
+    captureSettings.outputFile = parameters().get<string>("contour.capture.to");
 
     if (contour::captureScreen(captureSettings))
         return EXIT_SUCCESS;
@@ -156,7 +156,7 @@ crispy::cli::Command ContourApp::parameterDefinition() const
                         "Generates the terminfo source file that will reflect the features of this version of contour. Using - as value will write to stdout instead.",
                         {
                             CLI::Option{
-                                "output",
+                                "to",
                                 CLI::Value{""s},
                                 "Output file name to store the screen capture to. If - (dash) is given, the output will be written to standard output.",
                                 "FILE",
@@ -169,7 +169,7 @@ crispy::cli::Command ContourApp::parameterDefinition() const
                         "Generates configuration file with the default configuration.",
                         CLI::OptionList{
                             CLI::Option{
-                                "output",
+                                "to",
                                 CLI::Value{""s},
                                 "Output file name to store the config file to. If - (dash) is given, the output will be written to standard output.",
                                 "FILE",
@@ -189,7 +189,7 @@ crispy::cli::Command ContourApp::parameterDefinition() const
                                 CLI::Presence::Required
                             },
                             CLI::Option{
-                                "output",
+                                "to",
                                 CLI::Value{""s},
                                 "Output file name to store the shell integration file to. If - (dash) is given, the output will be written to standard output.",
                                 "FILE",
@@ -206,7 +206,7 @@ crispy::cli::Command ContourApp::parameterDefinition() const
                     CLI::Option{"logical", CLI::Value{false}, "Tells the terminal to use logical lines for counting and capturing."},
                     CLI::Option{"timeout", CLI::Value{1.0}, "Sets timeout seconds to wait for terminal to respond."},
                     CLI::Option{"lines", CLI::Value{0u}, "The number of lines to capture"},
-                    CLI::Option{"output", CLI::Value{""s}, "Output file name to store the screen capture to. If - (dash) is given, the capture will be written to standard output.", "FILE", CLI::Presence::Required},
+                    CLI::Option{"to", CLI::Value{""s}, "Output file name to store the screen capture to. If - (dash) is given, the capture will be written to standard output.", "FILE", CLI::Presence::Required},
                 }
             },
             CLI::Command{


### PR DESCRIPTION
This is how the CLI syntax would look like with this change:

![image](https://user-images.githubusercontent.com/56763/115858829-ba3e5f00-a42f-11eb-947d-4237ada1e553.png)

/cc @whisperity 