### PR TITLE
[CI] Fix CodeChecker again - `analyze` needs the exit status ignored

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,11 +33,10 @@ jobs:
       run: mkdir build
     - name: "cmake"
       run: |
-        cd build && cmake .. \
-          -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++-9 \
-          -DYAML_BUILD_SHARED_LIBS=OFF -DYAML_CPP_BUILD_CONTRIB=OFF \
-          -DYAML_CPP_BUILD_TESTS=OFF -DYAML_CPP_BUILD_TOOLS=OFF \
-          -DYAML_CPP_INSTALL=OFF
+        BUILD_DIR="build" \
+          CMAKE_BUILD_TYPE="Release" \
+          CXX="g++-9" \
+          ./scripts/ci-prepare-contour.sh
     - name: "build"
       run: cmake --build build/ -- -j3
     - name: "test: crispy"
@@ -66,12 +65,11 @@ jobs:
       run: mkdir build
     - name: "cmake"
       run: |
-        cd build && cmake .. \
-          -DCONTOUR_BLUR_PLATFORM_KWIN=ON \
-          -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_COMPILER=g++-9 \
-          -DYAML_BUILD_SHARED_LIBS=OFF -DYAML_CPP_BUILD_CONTRIB=OFF \
-          -DYAML_CPP_BUILD_TESTS=OFF -DYAML_CPP_BUILD_TOOLS=OFF \
-          -DYAML_CPP_INSTALL=OFF
+        BUILD_DIR="build" \
+          CMAKE_BUILD_TYPE="RelWithDebInfo" \
+          CXX="g++-9" \
+          EXTRA_CMAKE_FLAGS="-DCONTOUR_BLUR_PLATFORM_KWIN=ON" \
+          ./scripts/ci-prepare-contour.sh
     - name: "build"
       run: cmake --build build/ -- -j3
     - name: "test: crispy"
@@ -130,13 +128,11 @@ jobs:
       run: mkdir build
     - name: "cmake"
       run: |
-        cd build && cmake .. \
-          -DUSE_BOOST_FILESYSTEM=ON \
-          -DCONTOUR_BLUR_PLATFORM_KWIN=ON \
-          -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++-8 \
-          -DYAML_BUILD_SHARED_LIBS=OFF -DYAML_CPP_BUILD_CONTRIB=OFF \
-          -DYAML_CPP_BUILD_TESTS=OFF -DYAML_CPP_BUILD_TOOLS=OFF \
-          -DYAML_CPP_INSTALL=OFF
+        BUILD_DIR="build" \
+          CMAKE_BUILD_TYPE="Release" \
+          CXX="g++-8" \
+          EXTRA_CMAKE_FLAGS="-DCONTOUR_BLUR_PLATFORM_KWIN=ON -DUSE_BOOST_FILESYSTEM=ON" \
+          ./scripts/ci-prepare-contour.sh
     - name: "build"
       run: cmake --build build/ -- -j3
     - name: "test: crispy"

--- a/.github/workflows/codechecker-analysis.yml
+++ b/.github/workflows/codechecker-analysis.yml
@@ -25,11 +25,11 @@ jobs:
     env:
       # The version of LLVM to use. Needed to set the appropriate clang-XX
       # binaries.
-      LLVM_VER: 13
+      LLVM_VER: 12
       # Defined if the version above represents the latest available version.
       # (This is needed because the LLVM nightly PPA doesn't tag the latest
       # rolling version.)
-      LLVM_LATEST: "yes"
+      LLVM_LATEST: ""   # No.
 
       CODECHECKER_CONFIG: .github/codechecker/config.json
     steps:
@@ -94,17 +94,13 @@ jobs:
           echo "::set-output name=CODECHECKER_GITSEVEN::$(./build/CodeChecker/bin/CodeChecker analyzer-version | grep 'Git commit' | cut -d'|' -f 2 | cut -c 2-8)"
           popd
       - name: "Build Contour"
+        # Note: Keep this in sync with that in build.yml!
         run: |
-          mkdir Build
+          BUILD_DIR="Build" \
+            CMAKE_BUILD_TYPE="Debug" \
+            CXX="g++-9" \
+            ./scripts/ci-prepare-contour.sh
           pushd Build
-          cmake .. \
-            -DCMAKE_BUILD_TYPE=Debug \
-            -DCMAKE_CXX_COMPILER="g++-9" \
-            -DYAML_BUILD_SHARED_LIBS=OFF \
-            -DYAML_CPP_BUILD_CONTRIB=OFF \
-            -DYAML_CPP_BUILD_TESTS=OFF \
-            -DYAML_CPP_BUILD_TOOLS=OFF \
-            -DYAML_CPP_INSTALL=OFF
           "${{ steps.codechecker.outputs.CODECHECKER_PATH }}"/CodeChecker \
             log \
             --build "cmake --build . -- -j3" \

--- a/.github/workflows/codechecker-analysis.yml
+++ b/.github/workflows/codechecker-analysis.yml
@@ -14,9 +14,9 @@ on:
       - fix/**
       - improvement/**
       - wip
-    pull_requests:
-      branches:
-        - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   ubuntu_2004:
@@ -120,7 +120,8 @@ jobs:
             "logged_compilation.json" \
             --config "$CODECHECKER_CONFIG" \
             --jobs $(nproc) \
-            --output "Results"
+            --output "Results" \
+          || true
       - name: "Perform static analysis (CTU for pushes on master)"
         if: ${{ github.ref == 'refs/heads/master' && github.event_name == 'push' }}
         run: |
@@ -134,7 +135,8 @@ jobs:
             --output "Results" \
             \
             --ctu \
-            --ctu-ast-mode load-from-pch
+            --ctu-ast-mode load-from-pch \
+          || true
       - name: "Convert static analysis results to HTML"
         # Ignore the exit status of the parse command - the fact that we have
         # reports will be obvious from the arfect and the CI output.

--- a/scripts/ci-prepare-contour.sh
+++ b/scripts/ci-prepare-contour.sh
@@ -1,0 +1,54 @@
+#! /bin/bash
+
+set -e
+
+prepare_build_ubuntu()
+{
+   mkdir -pv ${BUILD_DIR}
+   cd ${BUILD_DIR}
+   cmake .. \
+      -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
+      -DCMAKE_CXX_COMPILER="${CXX}" \
+      -DYAML_BUILD_SHARED_LIBS=OFF \
+      -DYAML_CPP_BUILD_CONTRIB=OFF \
+      -DYAML_CPP_BUILD_TESTS=OFF \
+      -DYAML_CPP_BUILD_TOOLS=OFF \
+      -DYAML_CPP_INSTALL=OFF \
+      ${EXTRA_CMAKE_FLAGS}
+}
+
+main_linux()
+{
+    local ID=`lsb_release --id | awk '{print $NF}'`
+
+    case "${ID}" in
+        Ubuntu)
+            prepare_build_ubuntu
+            ;;
+        *)
+            echo "No automated build configuration is available yet."
+            ;;
+    esac
+}
+
+main_darwin()
+{
+    echo "No automated build configuration is available yet."
+}
+
+main()
+{
+    case "$OSTYPE" in
+        linux-gnu*)
+            main_linux
+            ;;
+        darwin*)
+            main_darwin
+            ;;
+        *)
+            echo "OS not supported."
+            ;;
+    esac
+}
+
+main


### PR DESCRIPTION
> Follow-up for #226

Sorry, I actually broke one half in the previous patch.