### PR TITLE
Adds rectangular area related VT sequences

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -38,6 +38,7 @@
 - Adds VT sequence `CSI Ps b` (`REP`) for repeating the last graphical character `Ps` times.
 - Adds VT sequence `OSC 4 ; INDEX ; COLOR ST` for setting or querying color palette (if COLOR is `?` instead of a color spec).
 - Adds VT sequence `OSC 104 ; INDEX ST` for resetting color palette entry or complete palette (if no (index is given).
+- Adds VT sequence `DECCRA` to copy a rectangular area.
 - Adds new CLI command: `contour capture ...` to capture the screen buffer.
 - Adds new CLI command: `contour set profile to NAME` to change the profile on the fly.
 - Adds new CLI command: `contour generate terminfo output OUTPUT_FILE` to create a Contour terminfo file.

--- a/Changelog.md
+++ b/Changelog.md
@@ -39,6 +39,7 @@
 - Adds VT sequence `OSC 4 ; INDEX ; COLOR ST` for setting or querying color palette (if COLOR is `?` instead of a color spec).
 - Adds VT sequence `OSC 104 ; INDEX ST` for resetting color palette entry or complete palette (if no (index is given).
 - Adds VT sequence `DECCRA` to copy a rectangular area.
+- Adds VT sequence `DECERA` to erase a rectangular area.
 - Adds new CLI command: `contour capture ...` to capture the screen buffer.
 - Adds new CLI command: `contour set profile to NAME` to change the profile on the fly.
 - Adds new CLI command: `contour generate terminfo output OUTPUT_FILE` to create a Contour terminfo file.

--- a/Changelog.md
+++ b/Changelog.md
@@ -40,6 +40,7 @@
 - Adds VT sequence `OSC 104 ; INDEX ST` for resetting color palette entry or complete palette (if no (index is given).
 - Adds VT sequence `DECCRA` to copy a rectangular area.
 - Adds VT sequence `DECERA` to erase a rectangular area.
+- Adds VT sequence `DECFRA` to fill a rectangular area.
 - Adds new CLI command: `contour capture ...` to capture the screen buffer.
 - Adds new CLI command: `contour set profile to NAME` to change the profile on the fly.
 - Adds new CLI command: `contour generate terminfo output OUTPUT_FILE` to create a Contour terminfo file.

--- a/src/terminal/Functions.h
+++ b/src/terminal/Functions.h
@@ -281,6 +281,7 @@ constexpr inline auto DA1         = detail::CSI(std::nullopt, 0, 1, std::nullopt
 constexpr inline auto DA2         = detail::CSI('>', 0, 1, std::nullopt, 'c', VTType::VT100, "DA2", "Send secondary device attributes");
 constexpr inline auto DA3         = detail::CSI('=', 0, 1, std::nullopt, 'c', VTType::VT100, "DA3", "Send tertiary device attributes");
 constexpr inline auto DCH         = detail::CSI(std::nullopt, 0, 1, std::nullopt, 'P', VTType::VT100, "DCH", "Delete characters");
+constexpr inline auto DECCRA      = detail::CSI(std::nullopt, 0, 8, '$', 'v', VTType::VT420, "DECCRA", "Copy rectangular area");
 constexpr inline auto DECDC       = detail::CSI(std::nullopt, 0, 1, '\'', '~', VTType::VT420, "DECDC", "Delete column");
 constexpr inline auto DECIC       = detail::CSI(std::nullopt, 0, 1, '\'', '}', VTType::VT420, "DECIC", "Insert column");
 constexpr inline auto DECMODERESTORE = detail::CSI('?', 0, ArgsMax, std::nullopt, 'r', VTType::VT525, "DECMODERESTORE", "Restore DEC private modes.");
@@ -415,6 +416,7 @@ inline auto const& functions() noexcept
             DA2,
             DA3,
             DCH,
+            DECCRA,
             DECDC,
             DECIC,
             DECMODERESTORE,
@@ -589,6 +591,7 @@ constexpr bool isBatchable(FunctionDefinition const& _function)
         case CUP:
         case CUU:
         case DCH:
+        case DECCRA:
         case DECDC:
         case DECIC:
         case DECSCUSR:

--- a/src/terminal/Functions.h
+++ b/src/terminal/Functions.h
@@ -26,7 +26,7 @@
 
 namespace terminal {
 
-enum class FunctionCategory {
+enum class FunctionCategory : uint8_t {
     C0   = 0,
     ESC  = 1,
     CSI  = 2,
@@ -35,35 +35,57 @@ enum class FunctionCategory {
 };
 
 /// Defines a function with all its syntax requirements plus some additional meta information.
-struct FunctionDefinition { // TODO: rename Function
+struct FunctionDefinition // TODO: rename Function
+{
     FunctionCategory category;  // (3 bits) C0, ESC, CSI, OSC, DCS
     char leader;                // (3 bits) 0x3C..0x3F (one of: < = > ?, or 0x00 for none)
     char intermediate;          // (4 bits) 0x20..0x2F (intermediates, usually just one, or 0x00 if none)
     char finalSymbol;           // (7 bits) 0x30..0x7E (final character)
-    int32_t minimumParameters;  // (4 bits) 0..7
-    int32_t maximumParameters;  // (7 bits) 0..127 or 0..2^7 for integer value (OSC function parameter)
+    uint8_t minimumParameters;  // (4 bits) 0..7
+    uint16_t maximumParameters; // (10 bits) 0..i024 for integer value (OSC function parameter)
 
     VTType conformanceLevel;
     std::string_view mnemonic;
     std::string_view comment;
 
-    constexpr unsigned id() const noexcept
+    using id_type = uint32_t;
+
+    constexpr id_type id() const noexcept
     {
-        switch (category)
-        {
-            case FunctionCategory::C0:
-                return static_cast<unsigned>(category) | finalSymbol << 3;
-            default:
-                return static_cast<unsigned>(category)
-                     | (!leader ? 0 :       (leader - 0x3C)       <<  3)
-                     | (!intermediate ? 0 : (intermediate - 0)    << (3 + 3))
-                     | (!finalSymbol ? 0 :  (finalSymbol - 0x30)  << (3 + 3 + 4))
-                     | minimumParameters                          << (3 + 3 + 4 + 7)
-                     | maximumParameters                          << (3 + 3 + 4 + 7 + 4);
-        }
+        unsigned constexpr CategoryShift      = 0;
+        unsigned constexpr LeaderShift        = 3;
+        unsigned constexpr IntermediateShift  = 3+3;
+        unsigned constexpr FinalShift         = 3+3+4;
+        unsigned constexpr MinParamShift      = 3+3+4+7;
+        unsigned constexpr MaxParamShift      = 3+3+4+7+4;
+
+        // if (category == FunctionCategory::C0)
+        //     return static_cast<id_type>(category) | finalSymbol << 3;
+
+        auto const maskCat = static_cast<id_type>(category) << CategoryShift;
+
+        // 0x3C..0x3F; (one of: < = > ?, or 0x00 for none)
+        auto const maskLeader = !leader
+            ? 0 : (static_cast<id_type>(leader) - 0x3C) << LeaderShift;
+
+        // 0x20..0x2F: (intermediates, usually just one, or 0x00 if none)
+        auto const maskInterm = !intermediate
+            ? 0 : (static_cast<id_type>(intermediate) - 0x20 + 1) << IntermediateShift;
+
+        // 0x40..0x7E: final character
+        auto const maskFinalS = !finalSymbol  ? 0 : (static_cast<id_type>(finalSymbol) - 0x40) << FinalShift;
+        auto const maskMinPar = minimumParameters << MinParamShift;
+        auto const maskMaxPar = maximumParameters << MaxParamShift;
+
+        return maskCat
+             | maskLeader
+             | maskInterm
+             | maskFinalS
+             | maskMinPar
+             | maskMaxPar;
     }
 
-    constexpr operator unsigned () const noexcept { return id(); }
+    constexpr operator id_type () const noexcept { return id(); }
 };
 
 constexpr int compare(FunctionDefinition const& a, FunctionDefinition const& b)
@@ -140,7 +162,7 @@ namespace detail // {{{
         return FunctionDefinition{FunctionCategory::C0, 0, 0, _final, 0, 0, VTType::VT100, _mnemonic, _description};
     }
 
-    constexpr auto OSC(int _code, std::string_view _mnemonic, std::string_view _description) noexcept
+    constexpr auto OSC(uint16_t _code, std::string_view _mnemonic, std::string_view _description) noexcept
     {
         return FunctionDefinition{FunctionCategory::OSC, 0, 0, 0, 0, _code, VTType::VT100, _mnemonic, _description};
     }
@@ -150,7 +172,7 @@ namespace detail // {{{
         return FunctionDefinition{FunctionCategory::ESC, 0, _intermediate.value_or(0), _final, 0, 0, _vt, _mnemonic, _description};
     }
 
-    constexpr auto CSI(std::optional<char> _leader, int _argc0, int _argc1, std::optional<char> _intermediate, char _final, VTType _vt, std::string_view _mnemonic, std::string_view _description) noexcept
+    constexpr auto CSI(std::optional<char> _leader, uint8_t _argc0, uint8_t _argc1, std::optional<char> _intermediate, char _final, VTType _vt, std::string_view _mnemonic, std::string_view _description) noexcept
     {
         // TODO: static_assert on _leader/_intermediate range-or-null
         return FunctionDefinition{
@@ -166,7 +188,7 @@ namespace detail // {{{
         };
     }
 
-    constexpr auto DCS(std::optional<char> _leader, int _argc0, int _argc1, std::optional<char> _intermediate, char _final, VTType _vt, std::string_view _mnemonic, std::string_view _description) noexcept
+    constexpr auto DCS(std::optional<char> _leader, uint8_t _argc0, uint8_t _argc1, std::optional<char> _intermediate, char _final, VTType _vt, std::string_view _mnemonic, std::string_view _description) noexcept
     {
         // TODO: static_assert on _leader/_intermediate range-or-null
         return FunctionDefinition{

--- a/src/terminal/Functions.h
+++ b/src/terminal/Functions.h
@@ -283,6 +283,7 @@ constexpr inline auto DA3         = detail::CSI('=', 0, 1, std::nullopt, 'c', VT
 constexpr inline auto DCH         = detail::CSI(std::nullopt, 0, 1, std::nullopt, 'P', VTType::VT100, "DCH", "Delete characters");
 constexpr inline auto DECCRA      = detail::CSI(std::nullopt, 0, 8, '$', 'v', VTType::VT420, "DECCRA", "Copy rectangular area");
 constexpr inline auto DECERA      = detail::CSI(std::nullopt, 0, 4, '$', 'z', VTType::VT420, "DECERA", "Erase rectangular area");
+constexpr inline auto DECFRA      = detail::CSI(std::nullopt, 0, 4, '$', 'x', VTType::VT420, "DECFRA", "Fill rectangular area");
 constexpr inline auto DECDC       = detail::CSI(std::nullopt, 0, 1, '\'', '~', VTType::VT420, "DECDC", "Delete column");
 constexpr inline auto DECIC       = detail::CSI(std::nullopt, 0, 1, '\'', '}', VTType::VT420, "DECIC", "Insert column");
 constexpr inline auto DECMODERESTORE = detail::CSI('?', 0, ArgsMax, std::nullopt, 'r', VTType::VT525, "DECMODERESTORE", "Restore DEC private modes.");
@@ -419,6 +420,7 @@ inline auto const& functions() noexcept
             DCH,
             DECCRA,
             DECERA,
+            DECFRA,
             DECDC,
             DECIC,
             DECMODERESTORE,

--- a/src/terminal/Functions.h
+++ b/src/terminal/Functions.h
@@ -282,6 +282,7 @@ constexpr inline auto DA2         = detail::CSI('>', 0, 1, std::nullopt, 'c', VT
 constexpr inline auto DA3         = detail::CSI('=', 0, 1, std::nullopt, 'c', VTType::VT100, "DA3", "Send tertiary device attributes");
 constexpr inline auto DCH         = detail::CSI(std::nullopt, 0, 1, std::nullopt, 'P', VTType::VT100, "DCH", "Delete characters");
 constexpr inline auto DECCRA      = detail::CSI(std::nullopt, 0, 8, '$', 'v', VTType::VT420, "DECCRA", "Copy rectangular area");
+constexpr inline auto DECERA      = detail::CSI(std::nullopt, 0, 4, '$', 'z', VTType::VT420, "DECERA", "Erase rectangular area");
 constexpr inline auto DECDC       = detail::CSI(std::nullopt, 0, 1, '\'', '~', VTType::VT420, "DECDC", "Delete column");
 constexpr inline auto DECIC       = detail::CSI(std::nullopt, 0, 1, '\'', '}', VTType::VT420, "DECIC", "Insert column");
 constexpr inline auto DECMODERESTORE = detail::CSI('?', 0, ArgsMax, std::nullopt, 'r', VTType::VT525, "DECMODERESTORE", "Restore DEC private modes.");
@@ -417,6 +418,7 @@ inline auto const& functions() noexcept
             DA3,
             DCH,
             DECCRA,
+            DECERA,
             DECDC,
             DECIC,
             DECMODERESTORE,

--- a/src/terminal/Screen.cpp
+++ b/src/terminal/Screen.cpp
@@ -1201,6 +1201,28 @@ void Screen::copyArea(int _top, int _left, int _bottom, int _right, int _page,
     updateCursorIterators();
 }
 
+void Screen::eraseArea(int _top, int _left, int _bottom, int _right)
+{
+    assert(_right <= size_.width);
+    assert(_bottom <= size_.height);
+
+    if (_top > _bottom || _left > _right)
+        return;
+
+    for (int y = _top; y <= _bottom; ++y)
+    {
+        Line& line = grid().lineAt(y);
+        auto column = next(begin(line), _left - 1);
+        for (int x = _left; x <= _right; ++x)
+        {
+            Cell& cell = *column;
+            cell.reset();
+            cell.setCharacter(0x20);
+            ++column;
+        }
+    }
+}
+
 void Screen::deleteLines(int _n)
 {
     if (isCursorInsideMargins())

--- a/src/terminal/Screen.cpp
+++ b/src/terminal/Screen.cpp
@@ -1223,6 +1223,26 @@ void Screen::eraseArea(int _top, int _left, int _bottom, int _right)
     }
 }
 
+void Screen::fillArea(char32_t _ch, int _top, int _left, int _bottom, int _right)
+{
+    // "Pch can be any value from 32 to 126 or from 160 to 255."
+    if (!(32 <= _ch && _ch <= 126) && !(160 <= _ch && _ch <= 255))
+        return;
+
+    for (int y = _top; y <= _bottom; ++y)
+    {
+        Line& line = grid().lineAt(y);
+        auto column = next(begin(line), _left - 1);
+        for (int x = _left; x <= _right; ++x)
+        {
+            Cell& cell = *column;
+            cell.reset(cursor().graphicsRendition);
+            cell.setCharacter(_ch);
+            ++column;
+        }
+    }
+}
+
 void Screen::deleteLines(int _n)
 {
     if (isCursorInsideMargins())

--- a/src/terminal/Screen.h
+++ b/src/terminal/Screen.h
@@ -242,6 +242,8 @@ class Screen : public capabilities::StaticDatabase {
         int _targetTop, int _targetLeft, int _targetPage
     );
 
+    void eraseArea(int _top, int _left, int _bottom, int _right);
+
     void deleteLines(int _n);      // DL
 
     void backIndex();    // DECBI

--- a/src/terminal/Screen.h
+++ b/src/terminal/Screen.h
@@ -244,6 +244,8 @@ class Screen : public capabilities::StaticDatabase {
 
     void eraseArea(int _top, int _left, int _bottom, int _right);
 
+    void fillArea(char32_t _ch, int _top, int _left, int _bottom, int _right);
+
     void deleteLines(int _n);      // DL
 
     void backIndex();    // DECBI

--- a/src/terminal/Screen.h
+++ b/src/terminal/Screen.h
@@ -237,6 +237,11 @@ class Screen : public capabilities::StaticDatabase {
     void insertLines(int _n);      // IL
     void insertColumns(int _n);    // DECIC
 
+    void copyArea(
+        int _top, int _left, int _bottom, int _right, int _page,
+        int _targetTop, int _targetLeft, int _targetPage
+    );
+
     void deleteLines(int _n);      // DL
 
     void backIndex();    // DECBI

--- a/src/terminal/Sequencer.cpp
+++ b/src/terminal/Sequencer.cpp
@@ -1552,6 +1552,21 @@ ApplyResult Sequencer::apply(FunctionDefinition const& _function, Sequence const
                                  targetTop, targetLeft, targetPage);
             }
             break;
+        case DECERA:
+            {
+                // The coordinates of the rectangular area are affected by the setting of origin mode (DECOM).
+                auto const origin = screen_.origin();
+                auto const top = _seq.param_or(0, Sequence::Parameter{ origin.row });
+                auto const left = _seq.param_or(1, Sequence::Parameter{ origin.column });
+
+                // If the value of Pt, Pl, Pb, or Pr exceeds the width or height of the active page, then the value is treated as the width or height of that page.
+                auto const size = screen_.size();
+                auto const bottom = min(_seq.param_or(2, Sequence::Parameter{ size.height }), size.height);
+                auto const right = min(_seq.param_or(3, Sequence::Parameter{ size.width }), size.width);
+
+                screen_.eraseArea(top, left, bottom, right);
+            }
+            break;
         case DECDC: screen_.deleteColumns(_seq.param_or(0, Sequence::Parameter{1})); break;
         case DECIC: screen_.insertColumns(_seq.param_or(0, Sequence::Parameter{1})); break;
         case DECRM:

--- a/src/terminal/Sequencer.cpp
+++ b/src/terminal/Sequencer.cpp
@@ -1533,6 +1533,25 @@ ApplyResult Sequencer::apply(FunctionDefinition const& _function, Sequence const
         case DA2: screen_.sendTerminalId(); break;
         case DA3: return ApplyResult::Unsupported;
         case DCH: screen_.deleteCharacters(_seq.param_or(0, Sequence::Parameter{1})); break;
+        case DECCRA:
+            {
+                // The coordinates of the rectangular area are affected by the setting of origin mode (DECOM).
+                // DECCRA is not affected by the page margins.
+                auto const origin = screen_.origin();
+                auto const top = _seq.param_or(0, Sequence::Parameter{ origin.row });
+                auto const left = _seq.param_or(1, Sequence::Parameter{ origin.column });
+                auto const bottom = _seq.param_or(2, Sequence::Parameter{ screen_.size().height });
+                auto const right = _seq.param_or(3, Sequence::Parameter{ screen_.size().width });
+                auto const page = _seq.param_or(4, Sequence::Parameter{ 0 });
+
+                auto const targetTop = _seq.param_or(5, Sequence::Parameter{ origin.row });
+                auto const targetLeft = _seq.param_or(6, Sequence::Parameter{ origin.column });
+                auto const targetPage = _seq.param_or(7, Sequence::Parameter{ 0 });
+
+                screen_.copyArea(top, left, bottom, right, page,
+                                 targetTop, targetLeft, targetPage);
+            }
+            break;
         case DECDC: screen_.deleteColumns(_seq.param_or(0, Sequence::Parameter{1})); break;
         case DECIC: screen_.insertColumns(_seq.param_or(0, Sequence::Parameter{1})); break;
         case DECRM:

--- a/src/terminal/Sequencer.cpp
+++ b/src/terminal/Sequencer.cpp
@@ -1567,6 +1567,22 @@ ApplyResult Sequencer::apply(FunctionDefinition const& _function, Sequence const
                 screen_.eraseArea(top, left, bottom, right);
             }
             break;
+        case DECFRA:
+            {
+                auto const ch = _seq.param_or(0, Sequence::Parameter{ 0 });
+                // The coordinates of the rectangular area are affected by the setting of origin mode (DECOM).
+                auto const origin = screen_.origin();
+                auto const top = _seq.param_or(0, Sequence::Parameter{ origin.row });
+                auto const left = _seq.param_or(1, Sequence::Parameter{ origin.column });
+
+                // If the value of Pt, Pl, Pb, or Pr exceeds the width or height of the active page, then the value is treated as the width or height of that page.
+                auto const size = screen_.size();
+                auto const bottom = min(_seq.param_or(2, Sequence::Parameter{ size.height }), size.height);
+                auto const right = min(_seq.param_or(3, Sequence::Parameter{ size.width }), size.width);
+
+                screen_.fillArea(ch, top, left, bottom, right);
+            }
+            break;
         case DECDC: screen_.deleteColumns(_seq.param_or(0, Sequence::Parameter{1})); break;
         case DECIC: screen_.insertColumns(_seq.param_or(0, Sequence::Parameter{1})); break;
         case DECRM:


### PR DESCRIPTION
- [x] `DECCRA` - copy rectangular area
- [x] `DECFRA` - fill rectangular area
- [x] `DECERA` - erase rectangular area

Closes #16, #18, #19.

### can be evaluated & done separately

 `DECRQCRA`- request checksum of rectangular area
