### PR TITLE
Fixes `ioctl(..., TIOCGWINSZ, ...)` pixel values that were only set during resize but not initially. Fixes #241.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ### 0.2.0 (unreleased)
 
 - Improved performance (optimized render loop, optimized grapheme cluster segmentation algorithm)
+- Fixes `ioctl(..., TIOCGWINSZ, ...)` pixel values that were only set during resize but not initially.
 - Fixes mouse in VIM+Vimspector to also change the document position when moving the mouse.
 - Fixes SGR decorations to use designated underline thickness and underline position.
 - Fixes font glyph render in some corner cases where the rendered glyph did result in rectangle garbage on the screen.

--- a/src/terminal/pty/UnixPty.cpp
+++ b/src/terminal/pty/UnixPty.cpp
@@ -41,6 +41,7 @@
 using crispy::Size;
 using std::runtime_error;
 using std::numeric_limits;
+using std::optional;
 using std::max;
 using namespace std::string_literals;
 
@@ -98,7 +99,7 @@ namespace
     }
 }
 
-UnixPty::UnixPty(Size const& _windowSize) :
+UnixPty::UnixPty(Size const& _windowSize, optional<Size> _pixels) :
     size_{ _windowSize }
 {
     // See https://code.woboq.org/userspace/glibc/login/forkpty.c.html
@@ -108,8 +109,8 @@ UnixPty::UnixPty(Size const& _windowSize) :
     winsize const ws{
         static_cast<unsigned short>(_windowSize.height),
         static_cast<unsigned short>(_windowSize.width),
-        0,
-        0
+        static_cast<unsigned short>(_pixels.value_or(Size{}).width),
+        static_cast<unsigned short>(_pixels.value_or(Size{}).height)
     };
 
 #if defined(__APPLE__)

--- a/src/terminal/pty/UnixPty.h
+++ b/src/terminal/pty/UnixPty.h
@@ -29,7 +29,7 @@ namespace terminal {
 class UnixPty : public Pty
 {
   public:
-    explicit UnixPty(crispy::Size const& windowSize);
+    explicit UnixPty(crispy::Size const& windowSize, std::optional<crispy::Size> _pixels = std::nullopt);
     ~UnixPty() override;
 
     int read(char* buf, size_t size, std::chrono::milliseconds _timeout) override;

--- a/src/terminal_view/TerminalView.cpp
+++ b/src/terminal_view/TerminalView.cpp
@@ -89,7 +89,9 @@ TerminalView::TerminalView(steady_clock::time_point _now,
     }
 {
     terminal_.screen().setCursorStyle(_cursorDisplay, _cursorShape);
-    terminal_.screen().setCellPixelSize(renderer_.cellSize());
+
+    // NB: Inform connected TTY and local Screen instance about initial cell pixel size.
+    terminal_.resizeScreen(terminal_.screenSize(), terminal_.screenSize() * cellSize());
 }
 
 void TerminalView::setRenderTarget(renderer::RenderTarget& _renderTarget)


### PR DESCRIPTION
Fixes #241