### PR TITLE
[contour] Some more OpenGL widget cleanups.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,6 +7,7 @@
   - show sixel
   - distor (`lsb_release`)
 
+- [ ] CHECK: profile change upon shortcut
 - [ ] config: warn on unknown yaml keys
 - [ ] TEST: RenderBuffer ops testable (esp. 2026)?
 - [ ] BUG? wrt RenderBuffer: maybe problem with vte emoji asset test? (one emoji)

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,15 +1,15 @@
 #! /bin/bash
 set -ex
 
+ROOTDIR="$(dirname $0)"
 BUILD_TYPE="${1:-Debug}"
 WORKDIR="build"
 if [[ "${BUILD_TYPE}" != "Debug" ]]; then
     WORKDIR="release"
 fi
 
-ROOTDIR="$(pwd)"
-mkdir -p "${WORKDIR}"
-cd "${WORKDIR}"
+mkdir -p "${ROOTDIR}/${WORKDIR}"
+cd "${ROOTDIR}/${WORKDIR}"
 
 exec cmake "${ROOTDIR}" \
            -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \

--- a/src/contour/TerminalDisplay.h
+++ b/src/contour/TerminalDisplay.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <contour/Config.h>
+#include <contour/helper.h>
 
 #include <terminal/InputGenerator.h>
 #include <terminal/Image.h>
@@ -26,13 +27,6 @@
 #include <functional>
 
 namespace contour {
-
-enum class MouseCursorShape {
-    Hidden,
-    PointingHand,
-    IBeam,
-    Arrow,
-};
 
 /**
  * VT Display interface.

--- a/src/contour/helper.h
+++ b/src/contour/helper.h
@@ -25,8 +25,9 @@
 #include <string>
 #include <string_view>
 
-namespace terminal::view {
-    class TerminalView;
+namespace terminal::renderer
+{
+    class Renderer;
 }
 
 namespace contour {
@@ -44,6 +45,14 @@ namespace detail {
        ~FunctionCallEvent() { fun(); }
     };
 }
+
+enum class MouseCursorShape
+{
+    Hidden,
+    PointingHand,
+    IBeam,
+    Arrow,
+};
 
 template <typename F>
 void postToObject(QObject* obj, F fun)
@@ -164,5 +173,35 @@ bool requestPermission(PermissionCache& _cache,
                        QWidget* _parent,
                        config::Permission _allowedByConfig,
                        std::string_view _topicText);
+
+terminal::FontDef getFontDefinition(terminal::renderer::Renderer& _renderer);
+
+terminal::renderer::PageMargin computeMargin(crispy::Size _cellSize, crispy::Size _charCells, crispy::Size _pixels) noexcept;
+
+bool applyFontDescription(
+    crispy::Size _cellSize,
+    crispy::Size _screenSize,
+    crispy::Size _pixelSize,
+    crispy::Point _screenDPI,
+    terminal::renderer::Renderer& _renderer,
+    terminal::renderer::FontDescriptions _fontDescriptions);
+
+constexpr Qt::CursorShape toQtMouseShape(MouseCursorShape _shape)
+{
+    switch (_shape)
+    {
+        case contour::MouseCursorShape::Hidden:
+            return Qt::CursorShape::BlankCursor;
+        case contour::MouseCursorShape::Arrow:
+            return Qt::CursorShape::ArrowCursor;
+        case contour::MouseCursorShape::IBeam:
+            return Qt::CursorShape::IBeamCursor;
+        case contour::MouseCursorShape::PointingHand:
+            return Qt::CursorShape::PointingHandCursor;
+    }
+
+    // should never be reached
+    return Qt::CursorShape::ArrowCursor;
+}
 
 }

--- a/src/contour/opengl/OpenGLRenderer.cpp
+++ b/src/contour/opengl/OpenGLRenderer.cpp
@@ -204,15 +204,13 @@ inline void bound(T& _bindable, Fn&& _callable)
 OpenGLRenderer::OpenGLRenderer(ShaderConfig const& _textShaderConfig,
                                ShaderConfig const& _rectShaderConfig,
                                Size _size,
-                               int _leftMargin,
-                               int _bottomMargin) :
+                               terminal::renderer::PageMargin _margin):
     size_{ _size },
     projectionMatrix_{ortho(
         0.0f, float(_size.width),      // left, right
         0.0f, float(_size.height)      // bottom, top
     )},
-    leftMargin_{ _leftMargin },
-    bottomMargin_{ _bottomMargin },
+    margin_{ _margin },
     textShader_{ createShader(_textShaderConfig) },
     textProjectionLocation_{ textShader_->uniformLocation("vs_projection") },
     // texture
@@ -292,10 +290,9 @@ void OpenGLRenderer::setRenderSize(Size _size)
     );
 }
 
-void OpenGLRenderer::setMargin(int _left, int _bottom) noexcept
+void OpenGLRenderer::setMargin(terminal::renderer::PageMargin _margin) noexcept
 {
-    leftMargin_ = _left;
-    bottomMargin_ = _bottom;
+    margin_ = _margin;
 }
 
 atlas::TextureAtlasAllocator& OpenGLRenderer::monochromeAtlasAllocator() noexcept

--- a/src/contour/opengl/OpenGLRenderer.h
+++ b/src/contour/opengl/OpenGLRenderer.h
@@ -40,13 +40,12 @@ class OpenGLRenderer final :
     OpenGLRenderer(ShaderConfig const& _textShaderConfig,
                    ShaderConfig const& _rectShaderConfig,
                    crispy::Size _size,
-                   int _leftMargin,
-                   int _bottomMargin);
+                   terminal::renderer::PageMargin _margin);
 
     ~OpenGLRenderer() override;
 
     void setRenderSize(crispy::Size _size) override;
-    void setMargin(int _left, int _bottom) noexcept override;
+    void setMargin(terminal::renderer::PageMargin _margin) noexcept override;
 
     atlas::TextureAtlasAllocator& monochromeAtlasAllocator() noexcept override;
     atlas::TextureAtlasAllocator& coloredAtlasAllocator() noexcept override;
@@ -98,8 +97,7 @@ class OpenGLRenderer final :
     crispy::Size size_;
     QMatrix4x4 projectionMatrix_;
 
-    int leftMargin_ = 0;
-    int bottomMargin_ = 0;
+    terminal::renderer::PageMargin margin_{};
 
     std::unique_ptr<QOpenGLShaderProgram> textShader_;
     int textProjectionLocation_;

--- a/src/contour/opengl/TerminalWidget.h
+++ b/src/contour/opengl/TerminalWidget.h
@@ -50,11 +50,6 @@ class TerminalWidget :
     Q_OBJECT
 
 public:
-    struct WindowMargin {
-        int left;
-        int bottom;
-    };
-
     TerminalWidget(config::TerminalProfile const& _profile,
                    TerminalSession& _session,
                    std::function<void()> _adaptSize,
@@ -158,7 +153,6 @@ public:
     void statsSummary();
     void doResize(crispy::Size _size);
     terminal::renderer::GridMetrics const& gridMetrics() const noexcept { return renderer_.gridMetrics(); }
-    WindowMargin computeMargin(crispy::Size _charCells, crispy::Size _pixels) const noexcept;
 
     /// Defines the current screen-dirtiness-vs-rendering state.
     ///
@@ -208,7 +202,6 @@ public:
     TerminalSession& session_;
     std::function<void()> adaptSize_;
     std::function<void(bool)> enableBackgroundBlur_;
-    WindowMargin windowMargin_{};
     terminal::renderer::Renderer renderer_;
     crispy::Size size_;                     // view size in pixels
     text::font_size fontSize_{};

--- a/src/terminal_renderer/GridMetrics.h
+++ b/src/terminal_renderer/GridMetrics.h
@@ -21,6 +21,20 @@
 
 namespace terminal::renderer {
 
+struct CellMargin
+{
+    int top = 0;
+    int left = 0;
+    int bottom = 0;
+    int right = 0;
+};
+
+struct PageMargin
+{
+    int left;
+    int bottom;
+};
+
 /// GridMetrics contains any valuable metrics required to calculate positions on the grid.
 struct GridMetrics
 {
@@ -34,17 +48,8 @@ struct GridMetrics
         int thickness = 1;  // underline thickness
     } underline{};
 
-    struct {
-        int top = 0;
-        int left = 0;
-        int bottom = 0;
-        int right = 0;
-    } cellMargin{};         // TODO: use me
-
-    struct {
-        int left = 0;
-        int bottom = 0;
-    } pageMargin{};
+    CellMargin cellMargin{}; // TODO: implement respecting cell margins.
+    PageMargin pageMargin{};
 
     /// Maps screen coordinates to target surface coordinates.
     ///

--- a/src/terminal_renderer/RenderTarget.h
+++ b/src/terminal_renderer/RenderTarget.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <terminal_renderer/Atlas.h>
+#include <terminal_renderer/GridMetrics.h>
 
 #include <terminal/Color.h>
 #include <terminal/Grid.h> // cell attribs
@@ -47,7 +48,7 @@ class RenderTarget
     virtual ~RenderTarget() = default;
 
     virtual void setRenderSize(crispy::Size _size) = 0;
-    virtual void setMargin(int _left, int _bottom) = 0;
+    virtual void setMargin(PageMargin _margin) = 0;
 
     virtual atlas::TextureAtlasAllocator& monochromeAtlasAllocator() noexcept = 0;
     virtual atlas::TextureAtlasAllocator& coloredAtlasAllocator() noexcept = 0;

--- a/src/terminal_renderer/Renderer.cpp
+++ b/src/terminal_renderer/Renderer.cpp
@@ -151,6 +151,12 @@ void Renderer::setFonts(FontDescriptions _fontDescriptions)
 
 bool Renderer::setFontSize(text::font_size _fontSize)
 {
+    if (_fontSize.pt < 5.) // Let's not be crazy.
+        return false;
+
+    if (_fontSize.pt > 200.)
+        return false;
+
     fontDescriptions_.size = _fontSize;
     fonts_ = loadFontKeys(fontDescriptions_, *textShaper_);
     updateFontMetrics();

--- a/src/terminal_renderer/Renderer.h
+++ b/src/terminal_renderer/Renderer.h
@@ -85,12 +85,11 @@ class Renderer : public Renderable {
         gridMetrics_.pageSize = _screenSize;
     }
 
-    void setMargin(int _leftMargin, int _bottomMargin) noexcept
+    void setMargin(PageMargin _margin) noexcept
     {
         if (renderTarget_)
-            renderTarget_->setMargin(_leftMargin, _bottomMargin);
-        gridMetrics_.pageMargin.left = _leftMargin;
-        gridMetrics_.pageMargin.bottom = _bottomMargin;
+            renderTarget_->setMargin(_margin);
+        gridMetrics_.pageMargin = _margin;
     }
 
     /**


### PR DESCRIPTION
moving some more non-OpenGL logic out of the OpenGL widget (`contour/opengl/TerminalWidget.cpp`) 