### PR TITLE
Fix invalid detection of source path in autogen script

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,7 +1,12 @@
 #! /bin/bash
 set -ex
 
-ROOTDIR="$(dirname $0)"
+if [[ -x "$(command -v realpath)" ]]; then
+  ROOTDIR="$(realpath $(dirname $0))"
+else
+  ROOTDIR="$(dirname $0)"
+fi
+
 BUILD_TYPE="${1:-Debug}"
 WORKDIR="build"
 if [[ "${BUILD_TYPE}" != "Debug" ]]; then


### PR DESCRIPTION
In zsh, realpath $0 returns ".", not an absolute path.
Thus it is necessary to obtain the absolute path since otherwise cmake "${ROOTDIR}" will look for a CMakeLists.txt in the build directory.