### PR TITLE
Adds action `ClearHistoryAndReset`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -32,6 +32,7 @@
 - Adds config option `profile.*.font.dpi_scale: FLOAT` to apply some additional DPI scaling on fonts.
 - Adds config option `profile.*.refresh_rate: FLOAT` to configure how often the terminal screen will be rendered at most when currently under heavy screen changes. A value of `"auto"` will use the currently connected monitor's refresh rate.
 - Adds configuration's action `ToggleAllKeyMaps` to enable/disable intercepting and interpreting keybinds. The one that did toggle it will not be disabled.
+- Adds configuration's action `ClearHistoryAndReset` to clear the history, and resetting the terminal.
 - Adds experimental config option `profile.*.font.text_shaping.method: METHOD` with possible values `complex`(defualt, fully featured) and `simple` (most simple with improved performance but less features) for selecting how to perform text shaping.
 - Adds VT sequence for enabling/disabling debug logging. `CSI ? 46 h` and `CSI ? 46 l` and CLI option `-d`.
 - Adds VT sequence for querying/setting current font `OSC 50 ; ? ST` and `OSC 50 ; Font ST` (and `OSC 60 Ps Ps Ps Ps Ps ST` for a more fine grained font query/setting control).

--- a/src/contour/Actions.cpp
+++ b/src/contour/Actions.cpp
@@ -49,11 +49,12 @@ namespace {
 optional<Action> fromString(string const& _name)
 {
     auto static const mappings = array{
-        mapAction<actions::FollowHyperlink>("FollowHyperlink"),
         mapAction<actions::ChangeProfile>("ChangeProfile"),
+        mapAction<actions::CopyPreviousMarkRange>("CopyPreviousMarkRange"),
         mapAction<actions::CopySelection>("CopySelection"),
         mapAction<actions::DecreaseFontSize>("DecreaseFontSize"),
         mapAction<actions::DecreaseOpacity>("DecreaseOpacity"),
+        mapAction<actions::FollowHyperlink>("FollowHyperlink"),
         mapAction<actions::IncreaseFontSize>("IncreaseFontSize"),
         mapAction<actions::IncreaseOpacity>("IncreaseOpacity"),
         mapAction<actions::NewTerminal>("NewTerminal"),
@@ -62,14 +63,17 @@ optional<Action> fromString(string const& _name)
         mapAction<actions::PasteClipboard>("PasteClipboard"),
         mapAction<actions::PasteSelection>("PasteSelection"),
         mapAction<actions::Quit>("Quit"),
+        mapAction<actions::ReloadConfig>("ReloadConfig"),
+        mapAction<actions::ResetConfig>("ResetConfig"),
+        mapAction<actions::ResetFontSize>("ResetFontSize"),
         mapAction<actions::ScreenshotVT>("ScreenshotVT"),
         mapAction<actions::ScrollDown>("ScrollDown"),
+        mapAction<actions::ScrollMarkDown>("ScrollMarkDown"),
+        mapAction<actions::ScrollMarkUp>("ScrollMarkUp"),
         mapAction<actions::ScrollOneDown>("ScrollOneDown"),
         mapAction<actions::ScrollOneUp>("ScrollOneUp"),
         mapAction<actions::ScrollPageDown>("ScrollPageDown"),
         mapAction<actions::ScrollPageUp>("ScrollPageUp"),
-        mapAction<actions::ScrollMarkUp>("ScrollMarkUp"),
-        mapAction<actions::ScrollMarkDown>("ScrollMarkDown"),
         mapAction<actions::ScrollToBottom>("ScrollToBottom"),
         mapAction<actions::ScrollToTop>("ScrollToTop"),
         mapAction<actions::ScrollUp>("ScrollUp"),
@@ -77,10 +81,6 @@ optional<Action> fromString(string const& _name)
         mapAction<actions::ToggleAllKeyMaps>("ToggleAllKeyMaps"),
         mapAction<actions::ToggleFullscreen>("ToggleFullscreen"),
         mapAction<actions::WriteScreen>("WriteScreen"),
-        mapAction<actions::ResetFontSize>("ResetFontSize"),
-        mapAction<actions::ReloadConfig>("ReloadConfig"),
-        mapAction<actions::ResetConfig>("ResetConfig"),
-        mapAction<actions::CopyPreviousMarkRange>("CopyPreviousMarkRange"),
     };
 
     auto const name = toLower(_name);

--- a/src/contour/Actions.cpp
+++ b/src/contour/Actions.cpp
@@ -50,6 +50,7 @@ optional<Action> fromString(string const& _name)
 {
     auto static const mappings = array{
         mapAction<actions::ChangeProfile>("ChangeProfile"),
+        mapAction<actions::ClearHistoryAndReset>("ClearHistoryAndReset"),
         mapAction<actions::CopyPreviousMarkRange>("CopyPreviousMarkRange"),
         mapAction<actions::CopySelection>("CopySelection"),
         mapAction<actions::DecreaseFontSize>("DecreaseFontSize"),

--- a/src/contour/Actions.h
+++ b/src/contour/Actions.h
@@ -22,6 +22,7 @@
 namespace contour::actions {
 
 struct ChangeProfile{ std::string name; };
+struct ClearHistoryAndReset{};
 struct CopyPreviousMarkRange{};
 struct CopySelection{};
 struct DecreaseFontSize{};
@@ -60,6 +61,7 @@ struct WriteScreen{ std::string chars; }; // "\033[2J\033[3J"
 
 using Action = std::variant<
     ChangeProfile,
+    ClearHistoryAndReset,
     CopyPreviousMarkRange,
     CopySelection,
     DecreaseFontSize,

--- a/src/contour/Actions.h
+++ b/src/contour/Actions.h
@@ -21,76 +21,76 @@
 
 namespace contour::actions {
 
-struct FollowHyperlink{};
-struct ToggleAllKeyMaps{};
-struct ToggleFullscreen{};
-struct ScreenshotVT{};
-struct IncreaseFontSize{};
-struct DecreaseFontSize{};
-struct IncreaseOpacity{};
-struct DecreaseOpacity{};
-struct SendChars{ std::string chars; };
-struct WriteScreen{ std::string chars; }; // "\033[2J\033[3J"
-struct ScrollOneUp{};
-struct ScrollOneDown{};
-struct ScrollUp{};
-struct ScrollDown{};
-struct ScrollPageUp{};
-struct ScrollPageDown{};
-struct ScrollMarkUp{};
-struct ScrollMarkDown{};
-struct ScrollToTop{};
-struct ScrollToBottom{};
-struct PasteClipboard{};
-struct CopySelection{};
-struct PasteSelection{};
 struct ChangeProfile{ std::string name; };
+struct CopyPreviousMarkRange{};
+struct CopySelection{};
+struct DecreaseFontSize{};
+struct DecreaseOpacity{};
+struct FollowHyperlink{};
+struct IncreaseFontSize{};
+struct IncreaseOpacity{};
 struct NewTerminal{ std::optional<std::string> profileName; };
 struct OpenConfiguration{};
 struct OpenFileManager{};
+struct PasteClipboard{};
+struct PasteSelection{};
 struct Quit{};
-struct ResetFontSize{};
 struct ReloadConfig{ std::optional<std::string> profileName; };
 struct ResetConfig{};
-struct CopyPreviousMarkRange{};
+struct ResetFontSize{};
+struct ScreenshotVT{};
+struct ScrollDown{};
+struct ScrollMarkDown{};
+struct ScrollMarkUp{};
+struct ScrollOneDown{};
+struct ScrollOneUp{};
+struct ScrollPageDown{};
+struct ScrollPageUp{};
+struct ScrollToBottom{};
+struct ScrollToTop{};
+struct ScrollUp{};
+struct SendChars{ std::string chars; };
+struct ToggleAllKeyMaps{};
+struct ToggleFullscreen{};
+struct WriteScreen{ std::string chars; }; // "\033[2J\033[3J"
 // CloseTab
-// OpenTab
 // FocusNextTab
 // FocusPreviousTab
+// OpenTab
 
 using Action = std::variant<
-    FollowHyperlink,
-    ResetFontSize,
-    ReloadConfig,
-    ResetConfig,
-    ToggleAllKeyMaps,
-    ToggleFullscreen,
-    ScreenshotVT,
-    IncreaseFontSize,
-    DecreaseFontSize,
-    IncreaseOpacity,
-    DecreaseOpacity,
-    SendChars,
-    WriteScreen,
-    ScrollOneUp,
-    ScrollOneDown,
-    ScrollUp,
-    ScrollDown,
-    ScrollPageUp,
-    ScrollPageDown,
-    ScrollMarkUp,
-    ScrollMarkDown,
-    ScrollToTop,
-    ScrollToBottom,
-    CopySelection,
-    PasteSelection,
-    PasteClipboard,
     ChangeProfile,
+    CopyPreviousMarkRange,
+    CopySelection,
+    DecreaseFontSize,
+    DecreaseOpacity,
+    FollowHyperlink,
+    IncreaseFontSize,
+    IncreaseOpacity,
     NewTerminal,
     OpenConfiguration,
     OpenFileManager,
+    PasteClipboard,
+    PasteSelection,
     Quit,
-    CopyPreviousMarkRange
+    ReloadConfig,
+    ResetConfig,
+    ResetFontSize,
+    ScreenshotVT,
+    ScrollDown,
+    ScrollMarkDown,
+    ScrollMarkUp,
+    ScrollOneDown,
+    ScrollOneUp,
+    ScrollPageDown,
+    ScrollPageUp,
+    ScrollToBottom,
+    ScrollToTop,
+    ScrollUp,
+    SendChars,
+    ToggleAllKeyMaps,
+    ToggleFullscreen,
+    WriteScreen
 >;
 
 std::optional<Action> fromString(std::string const& _name);

--- a/src/contour/TerminalSession.cpp
+++ b/src/contour/TerminalSession.cpp
@@ -412,6 +412,19 @@ void TerminalSession::operator()(actions::ChangeProfile const& _action)
     activateProfile(_action.name);
 }
 
+void TerminalSession::operator()(actions::ClearHistoryAndReset)
+{
+    debuglog(WidgetTag).write("Clearing history and perform terminal hard reset");
+
+    auto const screenSize = terminal_.screenSize();
+    auto const pixelSize = display_->pixelSize();
+
+    terminal_.resizeScreen(screenSize + crispy::Size{1, 0}, pixelSize);
+    terminal_.screen().resetHard();
+    this_thread::yield();
+    terminal_.resizeScreen(screenSize, pixelSize);
+}
+
 void TerminalSession::operator()(actions::CopyPreviousMarkRange)
 {
     copyToClipboard(terminal().extractLastMarkRange());

--- a/src/contour/TerminalSession.h
+++ b/src/contour/TerminalSession.h
@@ -99,6 +99,7 @@ class TerminalSession: public terminal::Terminal::Events
 
     // Actions
     void operator()(actions::ChangeProfile const&);
+    void operator()(actions::ClearHistoryAndReset);
     void operator()(actions::CopyPreviousMarkRange);
     void operator()(actions::CopySelection);
     void operator()(actions::DecreaseFontSize);

--- a/src/contour/contour.yml
+++ b/src/contour/contour.yml
@@ -287,6 +287,7 @@ color_schemes:
 #
 # Actions:
 # - ChangeProfile     Changes the profile to the given profile `name`.
+# - ClearHistoryAndReset    Clears the history, performs a terminal hard reset and attempts to force a redraw of the currently running application.
 # - CopyPreviousMarkRange   Copies the most recent range that is delimited by vertical line marks into clipboard.
 # - CopySelection     Copies the current selection into the clipboard buffer.
 # - DecreaseFontSize  Decreases the font size by 1 pixel.

--- a/src/contour/contour.yml
+++ b/src/contour/contour.yml
@@ -315,8 +315,7 @@ color_schemes:
 # - ScrollToTop       Scrolls to the top of the screen buffer.
 # - ScrollUp          Scrolls up by the multiplier factor.
 # - SendChars         Writes given characters in `chars` member to the applications input.
-# - ToggleAllKeyMaps  Disables/enables responding to all keybinds
-#                     (this keybind will be preserved when disabling all others).
+# - ToggleAllKeyMaps  Disables/enables responding to all keybinds (this keybind will be preserved when disabling all others).
 # - ToggleFullScreen  Enables/disables full screen mode.
 # - WriteScreen       Writes VT sequence in `chars` member to the screen (bypassing the application).
 


### PR DESCRIPTION
Implements "Clear Scrollback and reset" action.

A action for "Clear scrollback" can be done with adding a special action via `WriteChars` and sending `\e[3J`.

Refs #263.